### PR TITLE
server: Use list instead of set for disk parameter. fix #29

### DIFF
--- a/internal/common/structure.go
+++ b/internal/common/structure.go
@@ -53,6 +53,23 @@ func ExpandSakuraCloudIDs(d basetypes.SetValue) []iaastypes.ID {
 	return ids
 }
 
+func ExpandSakuraCloudIDsFromList(d basetypes.ListValue) []iaastypes.ID {
+	strIDs := TlistToStrings(d)
+	if len(strIDs) == 0 {
+		return nil
+	}
+
+	var ids []iaastypes.ID
+	for _, strID := range strIDs {
+		if strID == "" {
+			continue
+		}
+		ids = append(ids, SakuraCloudID(strID))
+	}
+
+	return ids
+}
+
 func GetZone(zone basetypes.StringValue, client *APIClient, diags *diag.Diagnostics) string {
 	if zone.IsNull() || zone.IsUnknown() {
 		return client.defaultZone

--- a/internal/service/server/data_source.go
+++ b/internal/service/server/data_source.go
@@ -80,10 +80,10 @@ func (d *serverDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 					iaastypes.CommitmentStrings,
 				),
 			},
-			"disks": schema.SetAttribute{
+			"disks": schema.ListAttribute{
 				ElementType: types.StringType,
 				Computed:    true,
-				Description: "A set of disk id connected to the server",
+				Description: "A list of disk id connected to the server",
 			},
 			"interface_driver": schema.StringAttribute{
 				Computed: true,

--- a/internal/service/server/model.go
+++ b/internal/service/server/model.go
@@ -22,7 +22,7 @@ type serverBaseModel struct {
 	GPUModel         types.String                  `tfsdk:"gpu_model"`
 	CPUModel         types.String                  `tfsdk:"cpu_model"`
 	Commitment       types.String                  `tfsdk:"commitment"`
-	Disks            types.Set                     `tfsdk:"disks"`
+	Disks            types.List                    `tfsdk:"disks"`
 	InterfaceDriver  types.String                  `tfsdk:"interface_driver"`
 	NetworkInterface []serverNetworkInterfaceModel `tfsdk:"network_interface"`
 	CDROMID          types.String                  `tfsdk:"cdrom_id"`
@@ -53,7 +53,7 @@ func (model *serverBaseModel) updateState(server *iaas.Server, zone string) {
 	model.GPUModel = types.StringValue(server.GPUModel)
 	model.CPUModel = types.StringValue(server.CPUModel)
 	model.Commitment = types.StringValue(server.Commitment.String())
-	model.Disks = common.StringsToTset(flattenServerConnectedDiskIDs(server))
+	model.Disks = common.StringsToTlist(flattenServerConnectedDiskIDs(server))
 	model.InterfaceDriver = types.StringValue(server.InterfaceDriver.String())
 	model.PrivateHostName = types.StringValue(server.PrivateHostName)
 	model.NetworkInterface = flattenServerNICs(server)

--- a/internal/service/server/resource.go
+++ b/internal/service/server/resource.go
@@ -145,12 +145,12 @@ func (r *serverResource) Schema(ctx context.Context, _ resource.SchemaRequest, r
 					stringvalidator.OneOf(iaastypes.CommitmentStrings...),
 				},
 			},
-			"disks": schema.SetAttribute{
+			"disks": schema.ListAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
-				Description: "A set of disk id connected to the server",
-				Validators: []validator.Set{
-					setvalidator.ValueStringsAre(sacloudvalidator.SakuraIDValidator()),
+				Description: "A list of disk id connected to the server",
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(sacloudvalidator.SakuraIDValidator()),
 				},
 			},
 			"interface_driver": schema.StringAttribute{
@@ -603,7 +603,7 @@ func expandServerUserData(plan *serverResourceModel, state *serverResourceModel)
 
 func expandServerDisks(ctx context.Context, client *common.APIClient, zone string, plan *serverResourceModel, state *serverResourceModel) ([]diskBuilder.Builder, error) {
 	var builders []diskBuilder.Builder
-	diskIDs := common.ExpandSakuraCloudIDs(plan.Disks)
+	diskIDs := common.ExpandSakuraCloudIDsFromList(plan.Disks)
 	diskOp := iaas.NewDiskOp(client)
 	for i, diskID := range diskIDs {
 		disk, err := diskOp.Read(ctx, zone, diskID)


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #29 

### このPRはどういう変更を行いますか？

serverリソースのdisksの型をSetからListに変更。

### ドキュメントの変更は必要ですか？

rc3出す時に一緒にあとで更新する。