### PR TITLE
eventbus_process_configuration: accept unknown state for credentials to support 'variable'

### DIFF
--- a/internal/service/eventbus/resource_process_configuration.go
+++ b/internal/service/eventbus/resource_process_configuration.go
@@ -67,19 +67,18 @@ func (r *processConfigurationResource) ValidateConfig(ctx context.Context, req r
 
 	switch destination := config.Destination.ValueString(); destination {
 	case destinationSimpleMQ:
-		if config.SimpleMQAPIKey.ValueString() == "" {
+		if !config.SimpleMQAPIKey.IsUnknown() && config.SimpleMQAPIKey.ValueString() == "" {
 			requiredAttributeMissing(resp, "simplemq_api_key_wo", destinationSimpleMQ)
 		}
 		version := config.CredentialsVersion
 		if version.IsNull() || version.IsUnknown() {
 			requiredAttributeMissing(resp, "credentials_wo_version", destinationSimpleMQ)
 		}
-
 	case destinationSimpleNotification, destinationAutoScale:
-		if config.SakuraAccessToken.ValueString() == "" {
+		if !config.SakuraAccessToken.IsUnknown() && config.SakuraAccessToken.ValueString() == "" {
 			requiredAttributeMissing(resp, "sakura_access_token_wo", destination)
 		}
-		if config.SakuraAccessTokenSecret.ValueString() == "" {
+		if !config.SakuraAccessTokenSecret.IsUnknown() && config.SakuraAccessTokenSecret.ValueString() == "" {
 			requiredAttributeMissing(resp, "sakura_access_token_secret_wo", destination)
 		}
 		version := config.CredentialsVersion

--- a/internal/service/eventbus/resource_process_configuration_test.go
+++ b/internal/service/eventbus/resource_process_configuration_test.go
@@ -82,6 +82,11 @@ func TestAccSakuraResourceProcessConfiguration_validation_credentials(t *testing
 				Config:      test.BuildConfigWithArgs(testAccSakuraProcessConfiguration_validation_SimpleMQCredential, rand),
 				ExpectError: regexp.MustCompile(`Expected "simplemq_api_key_wo" to be configured`),
 			},
+			{
+				Config:             test.BuildConfigWithArgs(testAccSakuraProcessConfiguration_validation_SimpleMQCredentialWithVariables, rand),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }
@@ -197,4 +202,21 @@ resource "sakura_eventbus_process_configuration" "foobar" {
   sakura_access_token_wo        = "test"
   sakura_access_token_secret_wo = "test"
   credentials_wo_version        = 1
+}`
+
+//nolint:gosec // hardcoded credentials but this is dummy data for test
+var testAccSakuraProcessConfiguration_validation_SimpleMQCredentialWithVariables = `
+// Using variable becomes unknown state in ValidateConfig
+variable "simplemq_api_key_testvalue" {
+  type = string
+  default = "foo"
+}
+
+resource "sakura_eventbus_process_configuration" "foobar" {
+  name        = "{{ .arg0 }}"
+
+  destination            = "simplemq"
+  parameters             = "{\"queue_name\": \"test-queue\", \"content\":\"TestContent\"}"
+  simplemq_api_key_wo    = var.simplemq_api_key_testvalue
+  credentials_wo_version = 1
 }`


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #68 

### このPRはどういう変更を行いますか？

variable経由では値が直接取れずunkown状態となるため、ValidateConfigで`IsUnkown`がtrueの時はエラーにしないようにする。

### ドキュメントの変更は必要ですか？

必要無し