### PR TITLE
disk: don't set empty string because dedicated_storage_id is optional

### DIFF
--- a/internal/service/disk/model.go
+++ b/internal/service/disk/model.go
@@ -36,7 +36,13 @@ func (model *diskBaseModel) updateState(disk *iaas.Disk, zone string) {
 	model.SourceDiskID = types.StringValue(disk.SourceDiskID.String())
 	model.ServerID = types.StringValue(disk.ServerID.String())
 	model.KMSKeyID = types.StringValue(disk.KMSKeyID.String())
-	model.DedicatedStorageID = types.StringValue(disk.Storage.DedicatedStorageContractID.String())
+	if disk.Storage != nil {
+		if disk.Storage.DedicatedStorageContractID.IsEmpty() {
+			model.DedicatedStorageID = types.StringNull()
+		} else {
+			model.DedicatedStorageID = types.StringValue(disk.Storage.DedicatedStorageContractID.String())
+		}
+	}
 	if disk.IconID.IsEmpty() {
 		model.IconID = types.StringNull()
 	} else {


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

新しく増えたdedicated_storage_idはOptionalフィールドなので、指定されていない場合は""ではなくnullとして扱う。

### ドキュメントの変更は必要ですか？

必要無し。