### PR TITLE
test: fix enhanced LB data source acc test plan expectation

### DIFF
--- a/internal/service/enhanced_lb/data_source_test.go
+++ b/internal/service/enhanced_lb/data_source_test.go
@@ -24,8 +24,7 @@ func TestAccSakuraDataSourceEnhancedLB_basic(t *testing.T) {
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:             test.BuildConfigWithArgs(testAccSakuraDataSourceEnhancedLB_basic, rand, ip0, ip1),
-				ExpectNonEmptyPlan: true,
+				Config: test.BuildConfigWithArgs(testAccSakuraDataSourceEnhancedLB_basic, rand, ip0, ip1),
 				Check: resource.ComposeTestCheckFunc(
 					test.CheckSakuraDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),


### PR DESCRIPTION
### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

#87 の補完

#87 によりELBの修正が行われたことでapply後にplan差分が出なくなった
これによりELBのDataSourceに対するテストの期待値も変更されたがテストコードに反映されていなかった

このPRでは`ExpectNonEmptyPlan: true`を削除することで差分が出ないことを期待するように修正した

### ドキュメントの変更は必要ですか？

no