### PR TITLE
sakura_dsr_lb: add retry and connect_timeout fields to vip.server

### DIFF
--- a/docs/data-sources/dsr_lb.md
+++ b/docs/data-sources/dsr_lb.md
@@ -65,8 +65,10 @@ Read-Only:
 
 Read-Only:
 
+- `connect_timeout` (Number) The timeout in seconds for health checks, available only for TCP/HTTP/HTTPS
 - `enabled` (Boolean) The flag to enable as destination of load balancing
 - `ip_address` (String) The IP address of the destination server
 - `path` (String) The path used when checking by HTTP/HTTPS
 - `protocol` (String) The protocol used for health checks. This will be one of [`http`/`https`/`tcp`/`ping`]
+- `retry` (Number) The retry count for server down detection, available only for TCP/HTTP/HTTPS
 - `status` (Number) The response code to expect when checking by HTTP/HTTPS

--- a/docs/resources/dsr_lb.md
+++ b/docs/resources/dsr_lb.md
@@ -125,6 +125,8 @@ Required:
 
 Optional:
 
+- `connect_timeout` (Number) The timeout in seconds for health checks, available only for TCP/HTTP/HTTPS
 - `enabled` (Boolean) The flag to enable as destination of load balancing
 - `path` (String) The path used when checking by HTTP/HTTPS
+- `retry` (Number) The retry count for server down detection, available only for TCP/HTTP/HTTPS
 - `status` (Number) The response code to expect when checking by HTTP/HTTPS

--- a/internal/service/dsr_lb/data_source.go
+++ b/internal/service/dsr_lb/data_source.go
@@ -110,6 +110,14 @@ func (r *dsrLBDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 										Computed:    true,
 										Description: "The response code to expect when checking by HTTP/HTTPS",
 									},
+									"retry": schema.Int32Attribute{
+										Computed:    true,
+										Description: "The retry count for server down detection, available only for TCP/HTTP/HTTPS",
+									},
+									"connect_timeout": schema.Int32Attribute{
+										Computed:    true,
+										Description: "The timeout in seconds for health checks, available only for TCP/HTTP/HTTPS",
+									},
 									"enabled": schema.BoolAttribute{
 										Computed:    true,
 										Description: "The flag to enable as destination of load balancing",

--- a/internal/service/dsr_lb/model.go
+++ b/internal/service/dsr_lb/model.go
@@ -28,11 +28,13 @@ type dsrLBNetworkInterfaceModel struct {
 }
 
 type dsrLBServerModel struct {
-	IPAddress types.String `tfsdk:"ip_address"`
-	Protocol  types.String `tfsdk:"protocol"`
-	Path      types.String `tfsdk:"path"`
-	Status    types.Int32  `tfsdk:"status"`
-	Enabled   types.Bool   `tfsdk:"enabled"`
+	IPAddress      types.String `tfsdk:"ip_address"`
+	Protocol       types.String `tfsdk:"protocol"`
+	Path           types.String `tfsdk:"path"`
+	Status         types.Int32  `tfsdk:"status"`
+	Retry          types.Int32  `tfsdk:"retry"`
+	ConnectTimeout types.Int32  `tfsdk:"connect_timeout"`
+	Enabled        types.Bool   `tfsdk:"enabled"`
 }
 
 type dsrLBVIPModel struct {
@@ -102,6 +104,19 @@ func flattenVIPs(lb *iaas.LoadBalancer) []dsrLBVIPModel {
 			} else {
 				server.Status = types.Int32Value(int32(s.HealthCheck.ResponseCode))
 			}
+
+			// pingではRetry/ConnectTimeoutは空になる
+			if s.HealthCheck.Retry.Int() == 0 {
+				server.Retry = types.Int32Null()
+			} else {
+				server.Retry = types.Int32Value(int32(s.HealthCheck.Retry))
+			}
+			if s.HealthCheck.ConnectTimeout.Int() == 0 {
+				server.ConnectTimeout = types.Int32Null()
+			} else {
+				server.ConnectTimeout = types.Int32Value(int32(s.HealthCheck.ConnectTimeout))
+			}
+
 			servers = append(servers, server)
 		}
 		vipModel := dsrLBVIPModel{

--- a/internal/service/dsr_lb/resource.go
+++ b/internal/service/dsr_lb/resource.go
@@ -169,6 +169,20 @@ func (r *dsrLBResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:    true,
 										Description: "The response code to expect when checking by HTTP/HTTPS",
 									},
+									"retry": schema.Int32Attribute{
+										Optional:    true,
+										Description: "The retry count for server down detection, available only for TCP/HTTP/HTTPS",
+										Validators: []validator.Int32{
+											int32validator.Between(1, 5),
+										},
+									},
+									"connect_timeout": schema.Int32Attribute{
+										Optional:    true,
+										Description: "The timeout in seconds for health checks, available only for TCP/HTTP/HTTPS",
+										Validators: []validator.Int32{
+											int32validator.Between(1, 30),
+										},
+									},
 									"enabled": schema.BoolAttribute{
 										Optional:    true,
 										Computed:    true,
@@ -414,6 +428,10 @@ func expandLoadBalancerVIPs(model *dsrLBResourceModel) []*iaas.LoadBalancerVirtu
 					Path:         s.Path.ValueString(),
 					ResponseCode: iaastypes.StringNumber(int(s.Status.ValueInt32())),
 				},
+			}
+			if s.Protocol.ValueString() != iaastypes.LoadBalancerHealthCheckProtocols.Ping.String() {
+				server.HealthCheck.Retry = iaastypes.StringNumber(int(s.Retry.ValueInt32()))
+				server.HealthCheck.ConnectTimeout = iaastypes.StringNumber(int(s.ConnectTimeout.ValueInt32()))
 			}
 			servers = append(servers, server)
 		}

--- a/internal/service/dsr_lb/resource_test.go
+++ b/internal/service/dsr_lb/resource_test.go
@@ -56,10 +56,14 @@ func TestAccSakuraDSRLB_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "vip.0.server.0.protocol", "http"),
 					resource.TestCheckResourceAttr(resourceName, "vip.0.server.0.path", "/ping.html"),
 					resource.TestCheckResourceAttr(resourceName, "vip.0.server.0.status", "200"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.0.retry", "3"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.0.connect_timeout", "10"),
 					resource.TestCheckResourceAttr(resourceName, "vip.0.server.1.ip_address", "192.168.11.52"),
 					resource.TestCheckResourceAttr(resourceName, "vip.0.server.1.protocol", "http"),
 					resource.TestCheckResourceAttr(resourceName, "vip.0.server.1.path", "/ping.html"),
 					resource.TestCheckResourceAttr(resourceName, "vip.0.server.1.status", "200"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.1.retry", "5"),
+					resource.TestCheckResourceAttr(resourceName, "vip.0.server.1.connect_timeout", "20"),
 					resource.TestCheckResourceAttr(resourceName, "vip.1.vip", "192.168.11.202"),
 					resource.TestCheckResourceAttr(resourceName, "vip.1.port", "443"),
 					resource.TestCheckResourceAttr(resourceName, "vip.1.delay_loop", "20"),
@@ -258,12 +262,16 @@ resource "sakura_dsr_lb" "foobar" {
       protocol   = "http"
       path       = "/ping.html"
       status     = 200
+      retry      = 3
+      connect_timeout = 10
     },
     {
       ip_address  = "192.168.11.52"
       protocol    = "http"
       path        = "/ping.html"
       status      = 200
+      retry      = 5
+      connect_timeout = 20
     }]
   },
   {


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

sakura_dsr_lbの実サーバの設定に`retry`と`connect_timeout`を追加します。
これは監視方法がping以外の場合に利用できるもので、コントロールパネルだと`サーバダウン判定のリトライ回数`と`ヘルスチェックのタイムアウト(秒)` に該当するものです。

テスト結果(該当部の抜粋):

```
$ TESTARGS="-run=DSRLB" SAKURA_ENABLE_DSRLB_TEST=1 make testacc

...

=== RUN   TestAccSakuraDataSourceDSRLB_basic
--- PASS: TestAccSakuraDataSourceDSRLB_basic (196.10s)
=== RUN   TestAccSakuraDSRLB_basic
--- PASS: TestAccSakuraDSRLB_basic (129.31s)
=== RUN   TestAccSakuraDSRLB_withRouter
--- PASS: TestAccSakuraDSRLB_withRouter (197.82s)
=== RUN   TestAccImportSakuraDSRLB_basic
--- PASS: TestAccImportSakuraDSRLB_basic (197.49s)
PASS
ok  	github.com/sacloud/terraform-provider-sakura/internal/service/dsr_lb	721.603s

...
```

### ドキュメントの変更は必要ですか？

yes, PRに含む