### PR TITLE
sakura_server: increase timeouts to 20 minutes

### DIFF
--- a/internal/service/server/resource.go
+++ b/internal/service/server/resource.go
@@ -445,7 +445,7 @@ func (r *serverResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	ctx, cancel := common.SetupTimeoutCreate(ctx, plan.Timeouts, common.Timeout5min)
+	ctx, cancel := common.SetupTimeoutCreate(ctx, plan.Timeouts, common.Timeout20min)
 	defer cancel()
 
 	zone := common.GetZone(plan.Zone, r.client, &resp.Diagnostics)
@@ -512,7 +512,7 @@ func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	ctx, cancel := common.SetupTimeoutUpdate(ctx, plan.Timeouts, common.Timeout5min)
+	ctx, cancel := common.SetupTimeoutUpdate(ctx, plan.Timeouts, common.Timeout20min)
 	defer cancel()
 
 	sid := state.ID.ValueString()


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

sakura_serverにおいてCreateとUpdateのタイムアウトを5分->20分に伸ばす

サーバの作成/更新は再起動やディスクの修正が行われる場合があるため、状況によっては現在のデフォルト値だとタイムアウトしてしまうことがある
このためデフォルトのタイムアウトを増やし20分とした

### ドキュメントの変更は必要ですか？

no