### PR TITLE
kms: Update kms-api-go to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/sacloud/iaas-api-go v1.25.0
 	github.com/sacloud/iaas-service-go v1.22.1
 	github.com/sacloud/iam-api-go v0.2.0
-	github.com/sacloud/kms-api-go v0.3.1
+	github.com/sacloud/kms-api-go v0.4.0
 	github.com/sacloud/nosql-api-go v0.2.0
 	github.com/sacloud/object-storage-api-go v0.0.12
 	github.com/sacloud/packages-go v0.0.12

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/sacloud/iaas-service-go v1.22.1 h1:0YgSrpU6a0y+EdTwYVYqjXzgAivcLt004c
 github.com/sacloud/iaas-service-go v1.22.1/go.mod h1:Y6Atlbd6r2G9vO84xKDvhV5jZtsJw7zolFOX1oa8Lfs=
 github.com/sacloud/iam-api-go v0.2.0 h1:lAzK7hPaf/flCzolX6YYmY5nYtGQaR8h7w9Fra7zdBE=
 github.com/sacloud/iam-api-go v0.2.0/go.mod h1:8qiBDobulUuldyjSvbchVzYi+UIcyHodr7guumvJARQ=
-github.com/sacloud/kms-api-go v0.3.1 h1:3cFJksswx/k2V44l7xojrtk7XORNrO21rLtwINH1PJE=
-github.com/sacloud/kms-api-go v0.3.1/go.mod h1:rUegqSJE8NO2/urIt26kx+x9N7wdjsETyGJMmJtKj5k=
+github.com/sacloud/kms-api-go v0.4.0 h1:F1/Cw7W2h6B/HWsoPDI7xMZkzFKphfVTBOHYh6DT2bM=
+github.com/sacloud/kms-api-go v0.4.0/go.mod h1:OSJD0mlzdZQXJPLbhBlAIthwxHISjWXhy9gHvUxieC0=
 github.com/sacloud/nosql-api-go v0.2.0 h1:zIQT3P66cnX2y86/1lQAznx1PlgPY4Y0IIRdzuqBtzE=
 github.com/sacloud/nosql-api-go v0.2.0/go.mod h1:YGHrq+t7CrxChQZeqUK6cVCMZHNEB5UsMa7qpctyuSQ=
 github.com/sacloud/object-storage-api-go v0.0.12 h1:sIjUrMSlxT5OPYuDv9tXF0NM1FJ81GgyCofhdisikUc=

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -384,7 +384,7 @@ func (c *Config) NewClient(envConf *Config) (*APIClient, error) {
 		zones = iaas.SakuraCloudZones
 	}
 
-	kmsClient, err := kms.NewClient(client.WithOptions(callerOptions))
+	kmsClient, err := kms.NewClient(theClient)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

kms-api-goがv0.4.0からsaclient-goベースになったので更新する。
kmsのテストは通ってます。

```
% TF_ACC=1 go test ./internal/service/kms -timeout=200m -v -count=1                                                 (git)-[update-kms-api-go]
=== RUN   TestAccSakuraDataSourceKMS_basic
--- PASS: TestAccSakuraDataSourceKMS_basic (22.08s)
=== RUN   TestFilterKMSByName
=== PAUSE TestFilterKMSByName
=== RUN   TestAccSakuraResourceKMS_basic
--- PASS: TestAccSakuraResourceKMS_basic (22.10s)
=== RUN   TestAccSakuraResourceKMS_imported
--- PASS: TestAccSakuraResourceKMS_imported (24.97s)
=== CONT  TestFilterKMSByName
=== RUN   TestFilterKMSByName/found_by_name
=== PAUSE TestFilterKMSByName/found_by_name
=== RUN   TestFilterKMSByName/not_found
=== PAUSE TestFilterKMSByName/not_found
=== CONT  TestFilterKMSByName/found_by_name
=== CONT  TestFilterKMSByName/not_found
--- PASS: TestFilterKMSByName (0.00s)
    --- PASS: TestFilterKMSByName/found_by_name (0.00s)
    --- PASS: TestFilterKMSByName/not_found (0.00s)
PASS
ok  	github.com/sacloud/terraform-provider-sakura/internal/service/kms	69.849s
```

サービスプリンシパルキーを経由するとテストの時間が倍になったりするので、この辺は時間がある時に検証した方がいいかもと思いました。

### ドキュメントの変更は必要ですか？

必要無し。