### PR TITLE
security_control_evaluation_rule: add support for object storage bucket encryption evaluation rule

### DIFF
--- a/internal/service/security_control/model_evaluation_rule.go
+++ b/internal/service/security_control/model_evaluation_rule.go
@@ -91,6 +91,19 @@ func flattenEvaluationRule(model *evaluationRuleBaseModel, rule *v1.EvaluationRu
 				Targets:            types.ListNull(types.StringType),
 			}
 		}
+	case "objectstorage-bucket-encryption-enabled":
+		r := rule.Rule.OneOf.ObjectStorageBucketEncryptionEnabled
+		model.ID = types.StringValue(string(r.EvaluationRuleId))
+		model.Description = types.StringValue(rule.Description.Value)
+		model.Enabled = types.BoolValue(rule.IsEnabled)
+		model.IamRolesRequired = common.StringsToTset(rule.IamRolesRequired)
+		if rule.IsEnabled {
+			model.Parameters = &evaluationRuleParametersModel{
+				ServicePrincipalID: types.StringValue(r.Parameter.Value.ServicePrincipalId.Value),
+				Targets:            flattenParameterObjectStorageEvaluationTarget(r.Parameter),
+			}
+		}
+
 	case "addon-datalake-no-public-access":
 		r := rule.Rule.OneOf.AddonDatalakeNoPublicAccess
 		model.ID = types.StringValue(string(r.EvaluationRuleId))
@@ -188,10 +201,20 @@ func flattenParameterTargets(targets v1.OptEvaluationRuleParametersZonedEvaluati
 		if len(targets.Value.Zones) == 0 {
 			v, _ := types.ListValue(types.StringType, []attr.Value{})
 			return v
-		} else {
-			return common.StringsToTlist(targets.Value.Zones)
 		}
-	} else {
-		return types.ListNull(types.StringType)
+		return common.StringsToTlist(targets.Value.Zones)
 	}
+	return types.ListNull(types.StringType)
+}
+
+func flattenParameterObjectStorageEvaluationTarget(targets v1.OptEvaluationRuleParametersObjectStorageEvaluationTarget) types.List {
+	if targets.IsSet() {
+		// StringsToTlist内で使われるListValueFromが[]に対してnullを返すため、明示的に空リストの場合の処理を追加
+		if len(targets.Value.Sites) == 0 {
+			v, _ := types.ListValue(types.StringType, []attr.Value{})
+			return v
+		}
+		return common.StringsToTlist(targets.Value.Sites)
+	}
+	return types.ListNull(types.StringType)
 }

--- a/internal/service/security_control/resource_evaluation_rule_test.go
+++ b/internal/service/security_control/resource_evaluation_rule_test.go
@@ -17,6 +17,7 @@ func TestAccSakuraSecurityControlEvaluationRule_basic(t *testing.T) {
 	resourceName1 := "sakura_security_control_evaluation_rule.foobar1"
 	resourceName2 := "sakura_security_control_evaluation_rule.foobar2"
 	resourceName3 := "sakura_security_control_evaluation_rule.foobar3"
+	resourceName4 := "sakura_security_control_evaluation_rule.foobar4"
 	id := os.Getenv("SAKURA_SERVICE_PRINCIPAL_ID")
 
 	resource.Test(t, resource.TestCase{
@@ -43,6 +44,14 @@ func TestAccSakuraSecurityControlEvaluationRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName3, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName3, "iam_roles_required.#", "1"),
 					resource.TestCheckResourceAttr(resourceName3, "no_action_on_delete", "false"),
+					resource.TestCheckResourceAttr(resourceName4, "id", "objectstorage-bucket-encryption-enabled"),
+					resource.TestCheckResourceAttr(resourceName4, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName4, "parameters.service_principal_id", id),
+					resource.TestCheckResourceAttr(resourceName4, "parameters.targets.#", "2"),
+					resource.TestCheckResourceAttr(resourceName4, "parameters.targets.0", "isk01"),
+					resource.TestCheckResourceAttr(resourceName4, "parameters.targets.1", "tky01"),
+					resource.TestCheckResourceAttr(resourceName4, "iam_roles_required.#", "1"),
+					resource.TestCheckResourceAttr(resourceName4, "no_action_on_delete", "false"),
 				),
 			},
 			{
@@ -62,6 +71,12 @@ func TestAccSakuraSecurityControlEvaluationRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName3, "enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName3, "iam_roles_required.#", "1"),
 					resource.TestCheckResourceAttr(resourceName3, "no_action_on_delete", "true"),
+					resource.TestCheckResourceAttr(resourceName4, "id", "objectstorage-bucket-encryption-enabled"),
+					resource.TestCheckResourceAttr(resourceName4, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName4, "parameters.service_principal_id", id),
+					resource.TestCheckResourceAttr(resourceName4, "parameters.targets.#", "0"),
+					resource.TestCheckResourceAttr(resourceName4, "iam_roles_required.#", "1"),
+					resource.TestCheckResourceAttr(resourceName4, "no_action_on_delete", "true"),
 				),
 			},
 		},
@@ -93,7 +108,16 @@ resource "sakura_security_control_evaluation_rule" "foobar3" {
   enabled = true
   no_action_on_delete = false
 }
-`
+
+resource "sakura_security_control_evaluation_rule" "foobar4" {
+  id      = "objectstorage-bucket-encryption-enabled"
+  enabled = true
+  no_action_on_delete = false
+  parameters = {
+    service_principal_id = "{{ .arg0 }}"
+    targets = ["isk01", "tky01"]
+  }
+}`
 
 const testAccSakuraSecurityControlEvaluationRule_update = `
 resource "sakura_security_control_evaluation_rule" "foobar1" {
@@ -119,4 +143,14 @@ resource "sakura_security_control_evaluation_rule" "foobar3" {
   id      = "addon-threat-detections"
   enabled = false
   no_action_on_delete = true
+}
+
+resource "sakura_security_control_evaluation_rule" "foobar4" {
+  id      = "objectstorage-bucket-encryption-enabled"
+  enabled = false
+  no_action_on_delete = true
+  parameters = {
+    service_principal_id = "{{ .arg0 }}"
+    targets = []
+  }
 }`


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

security_control_evaluation_ruleにおいて `objectstorage-bucket-encryption-enabled`をサポートする

利用例

```hcl
resource "sakura_security_control_evaluation_rule" "foobar4" {
  id      = "objectstorage-bucket-encryption-enabled"
  enabled = true
  no_action_on_delete = true
  parameters = {
    service_principal_id = "xx"
    targets = ["isk01"]
  }
}
```

### ドキュメントの変更は必要ですか？

no
