### PR TITLE
Use replica_password_wo instead of reading replication password from master database

### DIFF
--- a/docs/resources/database_read_replica.md
+++ b/docs/resources/database_read_replica.md
@@ -23,8 +23,8 @@ resource "sakura_kms" "foobar" {
 
 resource "sakura_database_read_replica" "foobar" {
   master_id                 = data.sakura_database.master.id
-  replica_user_password_wo     = "your-replica-password"
-  replica_user_password_wo_version = 1
+  replica_password_wo     = "your-replica-password"
+  replica_password_wo_version = 1
   network_interface = {
     ip_address = "192.168.11.111"
   }
@@ -50,14 +50,14 @@ resource "sakura_database_read_replica" "foobar" {
 - `master_id` (String) The id of the replication master database.
 - `name` (String) The name of the Database Read Replica.
 - `network_interface` (Attributes) (see [below for nested schema](#nestedatt--network_interface))
-- `replica_user_password_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The password of user that processing a replication
+- `replica_password_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The password of user that processing a replication
 
 ### Optional
 
 - `description` (String) The description of the Database Read Replica. The length of this value must be in the range [`1`-`512`]
 - `disk` (Attributes) (see [below for nested schema](#nestedatt--disk))
 - `icon_id` (String) The icon id to attach to the Database Read Replica
-- `replica_user_password_wo_version` (Number) The version of the replica_user_password_wo field. This value must be greater than 0 when set. Increment this when changing password.
+- `replica_password_wo_version` (Number) The version of the replica_password_wo field. This value must be greater than 0 when set. Increment this when changing password.
 - `tags` (Set of String) The tags of the Database Read Replica.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `zone` (String) The name of zone that the Database Read Replica will be created (e.g. `is1a`, `tk1a`)

--- a/examples/resources/sakura_database_read_replica/resource.tf
+++ b/examples/resources/sakura_database_read_replica/resource.tf
@@ -8,8 +8,8 @@ resource "sakura_kms" "foobar" {
 
 resource "sakura_database_read_replica" "foobar" {
   master_id                 = data.sakura_database.master.id
-  replica_user_password_wo     = "your-replica-password"
-  replica_user_password_wo_version = 1
+  replica_password_wo     = "your-replica-password"
+  replica_password_wo_version = 1
   network_interface = {
     ip_address = "192.168.11.111"
   }

--- a/internal/service/database/resource_read_replica.go
+++ b/internal/service/database/resource_read_replica.go
@@ -59,8 +59,8 @@ type databaseReadReplicaResourceModel struct {
 	IconID                       types.String                   `tfsdk:"icon_id"`
 	Zone                         types.String                   `tfsdk:"zone"`
 	MasterID                     types.String                   `tfsdk:"master_id"`
-	ReplicaUserPasswordWo        types.String                   `tfsdk:"replica_user_password_wo"`
-	ReplicaUserPasswordWoVersion types.Int32                    `tfsdk:"replica_user_password_wo_version"`
+	ReplicaPasswordWO        types.String                   `tfsdk:"replica_password_wo"`
+	ReplicaPasswordWOVersion types.Int32                    `tfsdk:"replica_password_wo_version"`
 	NetworkInterface             *databaseNetworkInterfaceModel `tfsdk:"network_interface"`
 	Disk                         types.Object                   `tfsdk:"disk"`
 	Timeouts                     timeouts.Value                 `tfsdk:"timeouts"`
@@ -85,20 +85,20 @@ func (r *databaseReadReplicaResource) Schema(ctx context.Context, _ resource.Sch
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"replica_user_password_wo": schema.StringAttribute{
+			"replica_password_wo": schema.StringAttribute{
 				Required:    true,
 				WriteOnly:   true,
 				Description: "The password of user that processing a replication",
 				Validators: []validator.String{
-					stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("replica_user_password_wo_version")),
+					stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("replica_password_wo_version")),
 				},
 			},
-			"replica_user_password_wo_version": schema.Int32Attribute{
+			"replica_password_wo_version": schema.Int32Attribute{
 				Optional:    true,
-				Description: "The version of the replica_user_password_wo field. This value must be greater than 0 when set. Increment this when changing password.",
+				Description: "The version of the replica_password_wo field. This value must be greater than 0 when set. Increment this when changing password.",
 				Validators: []validator.Int32{
 					int32validator.AtLeast(1),
-					int32validator.AlsoRequires(path.MatchRelative().AtParent().AtName("replica_user_password_wo")),
+					int32validator.AlsoRequires(path.MatchRelative().AtParent().AtName("replica_password_wo")),
 				},
 			},
 			"network_interface": schema.SingleNestedAttribute{
@@ -182,7 +182,7 @@ func (r *databaseReadReplicaResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
-	replicaPassword := config.ReplicaUserPasswordWo.ValueString()
+	replicaPassword := config.ReplicaPasswordWO.ValueString()
 	builder, err := expandDatabaseReadReplicaBuilder(ctx, &plan, replicaPassword, r.client, zone)
 	if err != nil {
 		resp.Diagnostics.AddError("Create: Expand Builder Error", fmt.Sprintf("failed to build Database Read Replica builder: %s", err))
@@ -244,7 +244,7 @@ func (r *databaseReadReplicaResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	replicaPassword := config.ReplicaUserPasswordWo.ValueString()
+	replicaPassword := config.ReplicaPasswordWO.ValueString()
 	builder, err := expandDatabaseReadReplicaBuilder(ctx, &plan, replicaPassword, r.client, zone)
 	if err != nil {
 		resp.Diagnostics.AddError("Update: Expand Builder Error", fmt.Sprintf("failed to build Database Read Replica builder: %s", err))

--- a/internal/service/database/resource_read_replica_test.go
+++ b/internal/service/database/resource_read_replica_test.go
@@ -121,7 +121,7 @@ func TestAccImportSakuraDatabaseReadReplica_basic(t *testing.T) {
 				ImportStateCheck:  checkFn,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"replica_user_password_wo_version",
+					"replica_password_wo_version",
 				},
 			},
 		},
@@ -182,8 +182,8 @@ resource "sakura_database" "foobar" {
 
 resource "sakura_database_read_replica" "foobar" {
   master_id    = sakura_database.foobar.id
-  replica_user_password_wo = "{{ .arg1 }}"
-  replica_user_password_wo_version = 1
+  replica_password_wo = "{{ .arg1 }}"
+  replica_password_wo_version = 1
   network_interface = {
     ip_address   = "192.168.151.111"
   }
@@ -233,8 +233,8 @@ resource "sakura_database" "foobar" {
 
 resource "sakura_database_read_replica" "foobar" {
   master_id = sakura_database.foobar.id
-  replica_user_password_wo = "{{ .arg1 }}"
-  replica_user_password_wo_version = 1
+  replica_password_wo = "{{ .arg1 }}"
+  replica_password_wo_version = 1
   network_interface = {
     ip_address   = "192.168.151.111"
   }
@@ -278,8 +278,8 @@ resource "sakura_database" "foobar" {
 
 resource "sakura_database_read_replica" "foobar" {
   master_id    = sakura_database.foobar.id
-  replica_user_password_wo = "{{ .arg1 }}"
-  replica_user_password_wo_version = 1
+  replica_password_wo = "{{ .arg1 }}"
+  replica_password_wo_version = 1
   network_interface = {
     ip_address = "192.168.152.111"
   }


### PR DESCRIPTION
### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

https://github.com/sacloud/terraform-provider-sakuracloud/pull/1355 のv3での対応
関連: #75 

v3でも同様の対応を行うが、こちらではレプリカユーザーのパスワードはWriteOnlyフィールドの慣習に則った形で以下2フィールドの追加とした。

- `replica_password_wo`
- `replica_password_wo_version`

> [!WARNING]
> この変更はbreaking-changeです
> すでにread_replicaを利用中の場合は次回のapply時にtfファイルを書き換えてreplica_password_woを指定する必要があります

テスト結果:

```
=== RUN   TestAccSakuraDatabaseReplica_basic
--- PASS: TestAccSakuraDatabaseReplica_basic (791.92s)
=== RUN   TestAccImportSakuraDatabaseReadReplica_basic
--- PASS: TestAccImportSakuraDatabaseReadReplica_basic (677.81s)
PASS
ok  	github.com/sacloud/terraform-provider-sakura/internal/service/database	1473.403s
```

### ドキュメントの変更は必要ですか？

yes, このPRに含む