### PR TITLE
fix: corrected the description of source_id in the example

### DIFF
--- a/docs/resources/simple_notification_routing.md
+++ b/docs/resources/simple_notification_routing.md
@@ -33,9 +33,8 @@ resource "sakura_simple_notification_routing" "foobar" {
   name            = "foobar" 
   description     = "description"
   tags            = ["foo","bar"]
-  icon_id         = sakura_icon.foobar.id
   match_labels    = []
-  source_id       = "<source-id>" 
+  source_id       = "2" # source id is "monitoring-suite. other services will be supported later.
   target_group_id = sakura_simple_notification_group.foobar.id
 }
 ```

--- a/examples/resources/sakura_simple_notification_routing/resource.tf
+++ b/examples/resources/sakura_simple_notification_routing/resource.tf
@@ -18,8 +18,7 @@ resource "sakura_simple_notification_routing" "foobar" {
   name            = "foobar" 
   description     = "description"
   tags            = ["foo","bar"]
-  icon_id         = sakura_icon.foobar.id
   match_labels    = []
-  source_id       = "<source-id>" 
+  source_id       = "2" # source id is "monitoring-suite. other services will be supported later.
   target_group_id = sakura_simple_notification_group.foobar.id
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？
Issueなし

### このPRはどういう変更を行いますか？
シンプル通知のrouting resource内 source_idに関するresource exampleの修正です。
現在指定可能なモニタリングスイートを設定するようにしました。

### ドキュメントの変更は必要ですか？
このPRに含まれています。