### PR TITLE
dependabot: Use groups for terraform and sacloud modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,13 @@ updates:
 
   - package-ecosystem: gomod
     directory: /
+    groups:
+      terraform:
+        patterns:
+          - "github.com/hashicorp/terraform-*"
+      sacloud:
+        patterns:
+          - "github.com/sacloud/*"
     schedule:
       interval: daily
       time: "05:00"


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

terraformやsacloudのモジュール群は関係していて一括で更新する必要が多いのもあり、グループ化して更新するようにする。

### ドキュメントの変更は必要ですか？

No