### PR TITLE
monitoring_suite: Make resource_id optional in routing resources. fix #188

### DIFF
--- a/docs/resources/monitoring_suite_log_routing.md
+++ b/docs/resources/monitoring_suite_log_routing.md
@@ -29,12 +29,12 @@ resource "sakura_monitoring_suite_log_routing" "foobar" {
 ### Required
 
 - `publisher_code` (String) The publisher code of the target service.
-- `resource_id` (String) The resource ID of the target service.
 - `storage_id` (String) The resource ID of the Log Storage.
 - `variant` (String) The variant of the Log Routing.
 
 ### Optional
 
+- `resource_id` (String) The resource ID of the target service.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only

--- a/docs/resources/monitoring_suite_metric_routing.md
+++ b/docs/resources/monitoring_suite_metric_routing.md
@@ -29,12 +29,12 @@ resource "sakura_monitoring_suite_metric_routing" "foobar" {
 ### Required
 
 - `publisher_code` (String) The publisher code of the target service.
-- `resource_id` (String) The resource ID of the target service.
 - `storage_id` (String) The resource ID of the Metric Storage.
 - `variant` (String) The variant of the Metric Routing.
 
 ### Optional
 
+- `resource_id` (String) The resource ID of the target service.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only

--- a/internal/service/monitoring_suite/model_log.go
+++ b/internal/service/monitoring_suite/model_log.go
@@ -108,7 +108,11 @@ type logRoutingBaseModel struct {
 
 func (model *logRoutingBaseModel) updateState(routing *monitoringsuiteapi.LogRouting) {
 	model.ID = types.StringValue(routing.UID.String())
-	model.ResourceID = types.StringValue(strconv.Itoa(int(routing.ResourceID.Value)))
+	if v, ok := routing.ResourceID.Get(); ok {
+		model.ResourceID = types.StringValue(strconv.FormatInt(v, 10))
+	} else {
+		model.ResourceID = types.StringNull()
+	}
 	model.StorageID = types.StringValue(strconv.Itoa(int(routing.LogStorage.ID)))
 	model.PublisherCode = types.StringValue(routing.Publisher.Code)
 	model.Variant = types.StringValue(routing.Variant)

--- a/internal/service/monitoring_suite/model_metric.go
+++ b/internal/service/monitoring_suite/model_metric.go
@@ -87,7 +87,11 @@ type metricRoutingBaseModel struct {
 
 func (model *metricRoutingBaseModel) updateState(routing *monitoringsuiteapi.MetricsRouting) {
 	model.ID = types.StringValue(routing.UID.String())
-	model.ResourceID = types.StringValue(strconv.Itoa(int(routing.ResourceID.Value)))
+	if v, ok := routing.ResourceID.Get(); ok {
+		model.ResourceID = types.StringValue(strconv.FormatInt(v, 10))
+	} else {
+		model.ResourceID = types.StringNull()
+	}
 	model.StorageID = types.StringValue(strconv.Itoa(int(routing.MetricsStorage.ID)))
 	model.PublisherCode = types.StringValue(routing.Publisher.Code)
 	model.Variant = types.StringValue(routing.Variant)

--- a/internal/service/monitoring_suite/resource_log_routing.go
+++ b/internal/service/monitoring_suite/resource_log_routing.go
@@ -58,7 +58,7 @@ func (r *logRoutingResource) Schema(ctx context.Context, _ resource.SchemaReques
 		Attributes: map[string]schema.Attribute{
 			"id": common.SchemaResourceId("Monitoring Suite Log Routing"),
 			"resource_id": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Description: "The resource ID of the target service.",
 			},
 			"storage_id": schema.StringAttribute{

--- a/internal/service/monitoring_suite/resource_log_routing_test.go
+++ b/internal/service/monitoring_suite/resource_log_routing_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -18,8 +19,11 @@ import (
 )
 
 func TestAccSakuraMonitoringSuiteLogRouting_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_LOG_STORAGE_ID")
+
 	resourceName := "sakura_monitoring_suite_log_routing.foobar"
 	rand := test.RandomName()
+	lsId := os.Getenv("SAKURA_MONITORING_SUITE_LOG_STORAGE_ID")
 
 	var storage monitoringsuiteapi.LogRouting
 	resource.Test(t, resource.TestCase{
@@ -28,7 +32,7 @@ func TestAccSakuraMonitoringSuiteLogRouting_basic(t *testing.T) {
 		CheckDestroy:             testCheckSakuraMonitoringSuiteLogRoutingDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteLogRouting_basic, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteLogRouting_basic, rand, lsId),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraMonitoringSuiteLogRoutingExists(resourceName, &storage),
 					resource.TestCheckResourceAttr(resourceName, "publisher_code", "simplemq"),
@@ -36,11 +40,11 @@ func TestAccSakuraMonitoringSuiteLogRouting_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_id", "sakura_simple_mq.foobar", "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "sakura_monitoring_suite_log_storage.foobar1", "id"),
+					resource.TestCheckResourceAttr(resourceName, "storage_id", lsId),
 				),
 			},
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteLogRouting_update, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteLogRouting_update, rand, lsId),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraMonitoringSuiteLogRoutingExists(resourceName, &storage),
 					resource.TestCheckResourceAttr(resourceName, "publisher_code", "simplemq"),
@@ -49,6 +53,47 @@ func TestAccSakuraMonitoringSuiteLogRouting_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_id", "sakura_simple_mq.foobar", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "sakura_monitoring_suite_log_storage.foobar2", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSakuraMonitoringSuiteLogRouting_withoutResourceID(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_LOG_STORAGE_ID")
+
+	resourceName := "sakura_monitoring_suite_log_routing.foobar"
+	rand := test.RandomName()
+	lsId := os.Getenv("SAKURA_MONITORING_SUITE_LOG_STORAGE_ID")
+
+	var storage monitoringsuiteapi.LogRouting
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraMonitoringSuiteLogRoutingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteLogRouting_basicWithoutResourceID, rand, lsId),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraMonitoringSuiteLogRoutingExists(resourceName, &storage),
+					resource.TestCheckResourceAttr(resourceName, "publisher_code", "simplemq"),
+					resource.TestCheckResourceAttr(resourceName, "variant", "simplemq_log"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckNoResourceAttr(resourceName, "resource_id"),
+					resource.TestCheckResourceAttr(resourceName, "storage_id", lsId),
+				),
+			},
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteLogRouting_updateWithoutResourceID, rand, lsId),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraMonitoringSuiteLogRoutingExists(resourceName, &storage),
+					resource.TestCheckResourceAttr(resourceName, "publisher_code", "simplemq"),
+					resource.TestCheckResourceAttr(resourceName, "variant", "simplemq_log"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_id", "sakura_simple_mq.foobar", "id"),
+					resource.TestCheckResourceAttr(resourceName, "storage_id", lsId),
 				),
 			},
 		},
@@ -108,9 +153,8 @@ resource "sakura_simple_mq" "foobar" {
   name = "{{ .arg0 }}"
 }
 
-resource "sakura_monitoring_suite_log_storage" "foobar1" {
-  name = "{{ .arg0 }}-1"
-  description = "description1"
+data "sakura_monitoring_suite_log_storage" "foobar1" {
+  id = "{{ .arg1 }}"
 }
 
 resource "sakura_monitoring_suite_log_storage" "foobar2" {
@@ -120,7 +164,7 @@ resource "sakura_monitoring_suite_log_storage" "foobar2" {
 
 resource "sakura_monitoring_suite_log_routing" "foobar" {
   resource_id = sakura_simple_mq.foobar.id
-  storage_id = sakura_monitoring_suite_log_storage.foobar1.id
+  storage_id = data.sakura_monitoring_suite_log_storage.foobar1.id
   publisher_code = "simplemq"
   variant = "simplemq_log"
 }
@@ -131,9 +175,8 @@ resource "sakura_simple_mq" "foobar" {
   name = "{{ .arg0 }}"
 }
 
-resource "sakura_monitoring_suite_log_storage" "foobar1" {
-  name = "{{ .arg0 }}-1"
-  description = "description1"
+data "sakura_monitoring_suite_log_storage" "foobar1" {
+  id = "{{ .arg1 }}"
 }
 
 resource "sakura_monitoring_suite_log_storage" "foobar2" {
@@ -148,3 +191,34 @@ resource "sakura_monitoring_suite_log_routing" "foobar" {
   variant = "simplemq_log"
 }
 `
+
+var testAccSakuraMonitoringSuiteLogRouting_basicWithoutResourceID = `
+resource "sakura_simple_mq" "foobar" {
+  name = "{{ .arg0 }}"
+}
+
+data "sakura_monitoring_suite_log_storage" "foobar" {
+  id = "{{ .arg1 }}"
+}
+
+resource "sakura_monitoring_suite_log_routing" "foobar" {
+  storage_id = data.sakura_monitoring_suite_log_storage.foobar.id
+  publisher_code = "simplemq"
+  variant = "simplemq_log"
+}`
+
+var testAccSakuraMonitoringSuiteLogRouting_updateWithoutResourceID = `
+resource "sakura_simple_mq" "foobar" {
+  name = "{{ .arg0 }}"
+}
+
+data "sakura_monitoring_suite_log_storage" "foobar" {
+  id = "{{ .arg1 }}"
+}
+
+resource "sakura_monitoring_suite_log_routing" "foobar" {
+  resource_id = sakura_simple_mq.foobar.id
+  storage_id = data.sakura_monitoring_suite_log_storage.foobar.id
+  publisher_code = "simplemq"
+  variant = "simplemq_log"
+}`

--- a/internal/service/monitoring_suite/resource_metric_routing.go
+++ b/internal/service/monitoring_suite/resource_metric_routing.go
@@ -58,7 +58,7 @@ func (r *metricRoutingResource) Schema(ctx context.Context, _ resource.SchemaReq
 		Attributes: map[string]schema.Attribute{
 			"id": common.SchemaResourceId("Monitoring Suite Metric Routing"),
 			"resource_id": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Description: "The resource ID of the target service.",
 			},
 			"storage_id": schema.StringAttribute{

--- a/internal/service/monitoring_suite/resource_metric_routing_test.go
+++ b/internal/service/monitoring_suite/resource_metric_routing_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -18,8 +19,11 @@ import (
 )
 
 func TestAccSakuraMonitoringSuiteMetricRouting_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
+
 	resourceName := "sakura_monitoring_suite_metric_routing.foobar"
 	rand := test.RandomName()
+	msId := os.Getenv("SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
 
 	var storage monitoringsuiteapi.MetricsRouting
 	resource.Test(t, resource.TestCase{
@@ -36,7 +40,7 @@ func TestAccSakuraMonitoringSuiteMetricRouting_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_id", "sakura_simple_mq.foobar", "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "sakura_monitoring_suite_metric_storage.foobar1", "id"),
+					resource.TestCheckResourceAttr(resourceName, "storage_id", msId),
 				),
 			},
 			{
@@ -49,6 +53,47 @@ func TestAccSakuraMonitoringSuiteMetricRouting_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 					resource.TestCheckResourceAttrPair(resourceName, "resource_id", "sakura_simple_mq.foobar", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "sakura_monitoring_suite_metric_storage.foobar2", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSakuraMonitoringSuiteMetricRouting_withoutResourceID(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
+
+	resourceName := "sakura_monitoring_suite_metric_routing.foobar"
+	rand := test.RandomName()
+	msId := os.Getenv("SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
+
+	var storage monitoringsuiteapi.MetricsRouting
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraMonitoringSuiteMetricRoutingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteMetricRouting_basicWithoutResourceID, rand, msId),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraMonitoringSuiteMetricRoutingExists(resourceName, &storage),
+					resource.TestCheckResourceAttr(resourceName, "publisher_code", "simplemq"),
+					resource.TestCheckResourceAttr(resourceName, "variant", "simplemq_metrics"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckNoResourceAttr(resourceName, "resource_id"),
+					resource.TestCheckResourceAttr(resourceName, "storage_id", msId),
+				),
+			},
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteMetricRouting_updateWithoutResourceID, rand, msId),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraMonitoringSuiteMetricRoutingExists(resourceName, &storage),
+					resource.TestCheckResourceAttr(resourceName, "publisher_code", "simplemq"),
+					resource.TestCheckResourceAttr(resourceName, "variant", "simplemq_metrics"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrPair(resourceName, "resource_id", "sakura_simple_mq.foobar", "id"),
+					resource.TestCheckResourceAttr(resourceName, "storage_id", msId),
 				),
 			},
 		},
@@ -108,9 +153,8 @@ resource "sakura_simple_mq" "foobar" {
   name = "{{ .arg0 }}"
 }
 
-resource "sakura_monitoring_suite_metric_storage" "foobar1" {
-  name = "{{ .arg0 }}-1"
-  description = "description1"
+data "sakura_monitoring_suite_metric_storage" "foobar1" {
+  id = "{{ .arg1 }}"
 }
 
 resource "sakura_monitoring_suite_metric_storage" "foobar2" {
@@ -120,20 +164,18 @@ resource "sakura_monitoring_suite_metric_storage" "foobar2" {
 
 resource "sakura_monitoring_suite_metric_routing" "foobar" {
   resource_id = sakura_simple_mq.foobar.id
-  storage_id = sakura_monitoring_suite_metric_storage.foobar1.id
+  storage_id = data.sakura_monitoring_suite_metric_storage.foobar1.id
   publisher_code = "simplemq"
   variant = "simplemq_metrics"
-}
-`
+}`
 
 var testAccSakuraMonitoringSuiteMetricRouting_update = `
 resource "sakura_simple_mq" "foobar" {
   name = "{{ .arg0 }}"
 }
 
-resource "sakura_monitoring_suite_metric_storage" "foobar1" {
-  name = "{{ .arg0 }}-1"
-  description = "description1"
+data "sakura_monitoring_suite_metric_storage" "foobar1" {
+  id = "{{ .arg1 }}"
 }
 
 resource "sakura_monitoring_suite_metric_storage" "foobar2" {
@@ -146,5 +188,35 @@ resource "sakura_monitoring_suite_metric_routing" "foobar" {
   storage_id = sakura_monitoring_suite_metric_storage.foobar2.id
   publisher_code = "simplemq"
   variant = "simplemq_metrics"
+}`
+
+var testAccSakuraMonitoringSuiteMetricRouting_basicWithoutResourceID = `
+resource "sakura_simple_mq" "foobar" {
+  name = "{{ .arg0 }}"
 }
-`
+
+data "sakura_monitoring_suite_metric_storage" "foobar" {
+  id = "{{ .arg1 }}"
+}
+
+resource "sakura_monitoring_suite_metric_routing" "foobar" {
+  storage_id = data.sakura_monitoring_suite_metric_storage.foobar.id
+  publisher_code = "simplemq"
+  variant = "simplemq_metrics"
+}`
+
+var testAccSakuraMonitoringSuiteMetricRouting_updateWithoutResourceID = `
+resource "sakura_simple_mq" "foobar" {
+  name = "{{ .arg0 }}"
+}
+
+data "sakura_monitoring_suite_metric_storage" "foobar" {
+  id = "{{ .arg1 }}"
+}
+
+resource "sakura_monitoring_suite_metric_routing" "foobar" {
+  resource_id = sakura_simple_mq.foobar.id
+  storage_id = data.sakura_monitoring_suite_metric_storage.foobar.id
+  publisher_code = "simplemq"
+  variant = "simplemq_metrics"
+}`


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #188

### このPRはどういう変更を行いますか？

モニタリングスイートのルーティングリソースのresource_idをOptionalにする。
テストの負荷軽減のため、ベースとなるlog_storage/metric_storageを既存のを指定するようにしました。

### ドキュメントの変更は必要ですか？

docsへの反映も同梱済み