### PR TITLE
container_registry: Remove readwrite usage from access_level

### DIFF
--- a/docs/resources/container_registry.md
+++ b/docs/resources/container_registry.md
@@ -36,7 +36,7 @@ variable users {
 resource "sakura_container_registry" "foobar" {
   name            = "foobar"
   subdomain_label = "your-subdomain-label"
-  access_level    = "readwrite" # this must be one of ["readwrite"/"readonly"/"none"]
+  access_level    = "none" # this must be one of ["none"/"readonly"]
 
   description = "description"
   tags        = ["tag1", "tag2"]
@@ -57,7 +57,7 @@ resource "sakura_container_registry" "foobar" {
 
 ### Required
 
-- `access_level` (String) The level of access that allow to users. This must be one of [`readwrite`/`readonly`/`none`]
+- `access_level` (String) The level of access that allow to users. This must be one of [`readonly`/`none`]
 - `name` (String) The name of the Container Registry.
 - `subdomain_label` (String) The label at the lowest of the FQDN used when be accessed from users. The length of this value must be in the range [`1`-`64`]
 

--- a/examples/resources/sakura_container_registry/resource.tf
+++ b/examples/resources/sakura_container_registry/resource.tf
@@ -21,7 +21,7 @@ variable users {
 resource "sakura_container_registry" "foobar" {
   name            = "foobar"
   subdomain_label = "your-subdomain-label"
-  access_level    = "readwrite" # this must be one of ["readwrite"/"readonly"/"none"]
+  access_level    = "none" # this must be one of ["none"/"readonly"]
 
   description = "description"
   tags        = ["tag1", "tag2"]

--- a/internal/service/container_registry/data_source_test.go
+++ b/internal/service/container_registry/data_source_test.go
@@ -27,6 +27,7 @@ func TestAccSakuraDataSourceContainerRegistry_basic(t *testing.T) {
 					test.CheckSakuraDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
+					resource.TestCheckResourceAttr(resourceName, "access_level", "none"),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "user.0.name", "user1"),
 					resource.TestCheckResourceAttr(resourceName, "user.0.permission", "readwrite"),
@@ -42,7 +43,7 @@ var testAccSakuraDataSourceContainerRegistry_basic = `
 resource "sakura_container_registry" "foobar" {
   name            = "{{ .arg0 }}"
   subdomain_label = "{{ .arg1 }}"
-  access_level    = "readwrite"
+  access_level    = "none"
 
   description = "description"
   tags        = ["tag1", "tag2"]

--- a/internal/service/container_registry/resource_test.go
+++ b/internal/service/container_registry/resource_test.go
@@ -40,7 +40,7 @@ func TestAccSakuraContainerRegistry_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
 					resource.TestCheckResourceAttr(resourceName, "virtual_domain", subDomainLabel+".usacloud.jp"),
 					resource.TestCheckResourceAttr(resourceName, "fqdn", subDomainLabel+".sakuracr.jp"),
-					resource.TestCheckResourceAttr(resourceName, "access_level", "readwrite"),
+					resource.TestCheckResourceAttr(resourceName, "access_level", "readonly"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1"),
@@ -66,7 +66,7 @@ func TestAccSakuraContainerRegistry_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
 					resource.TestCheckResourceAttr(resourceName, "virtual_domain", subDomainLabel+"-upd.usacloud.jp"),
 					resource.TestCheckResourceAttr(resourceName, "fqdn", subDomainLabel+".sakuracr.jp"),
-					resource.TestCheckResourceAttr(resourceName, "access_level", "readonly"),
+					resource.TestCheckResourceAttr(resourceName, "access_level", "none"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description-upd"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1-upd"),
@@ -137,7 +137,7 @@ resource "sakura_container_registry" "foobar" {
   name            = "{{ .arg0 }}"
   virtual_domain  = "{{ .arg1 }}.usacloud.jp"
   subdomain_label = "{{ .arg1 }}"
-  access_level    = "readwrite"
+  access_level    = "readonly"
 
   description = "description"
   tags        = ["tag1", "tag2"]
@@ -166,7 +166,7 @@ resource "sakura_container_registry" "foobar" {
   name            = "{{ .arg0 }}-upd"
   virtual_domain  = "{{ .arg1 }}-upd.usacloud.jp"
   subdomain_label = "{{ .arg1 }}"
-  access_level    = "readonly"
+  access_level    = "none"
 
   description = "description-upd"
   tags        = ["tag1-upd", "tag2-upd"]


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

https://cloud.sakura.ad.jp/news/2026/01/22/containerregistry-privacysettings/ に従って、terraformの設定等からreadwriteの使用例を削除してreadonly/noneを使うようにする。

### ドキュメントの変更は必要ですか？

設定例も変更