### PR TITLE
Remove S3 Checksum Skips

### DIFF
--- a/docs/guides/object-storage-for-tf-backend.md
+++ b/docs/guides/object-storage-for-tf-backend.md
@@ -49,17 +49,6 @@ aws_secret_access_key = "object-storage-secret-key"
 
 Obtain these values by creating a site and permissions.
 
-- Additional Environment Variables
-
-You need to set following environment variables to avoid API error.
-
-```
-AWS_REQUEST_CHECKSUM_CALCULATION=WHEN_REQUIRED
-AWS_RESPONSE_CHECKSUM_VALIDATION=WHEN_REQUIRED
-```
-
-See also: https://cloud.sakura.ad.jp/news/2025/02/04/objectstorage_defectversion/
-
 ## Notes
 
 Due to current API limitations, the `use_lockfile` parameter cannot be used when using Sakura's Object Storage.

--- a/docs/guides/object-storage-for-tf-backend.md
+++ b/docs/guides/object-storage-for-tf-backend.md
@@ -32,7 +32,6 @@ terraform {
     skip_metadata_api_check     = true
     skip_region_validation      = true
     skip_requesting_account_id  = true
-    skip_s3_checksum            = true
   }
 }
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？
該当Issueありません

### このPRはどういう変更を行いますか？
さくらのS3を使用する際にChecksumのskip設定および環境変数が不要になったので、ドキュメントから対象部分を
削除します。
https://cloud.sakura.ad.jp/news/2026/04/09/objectstorage-checksum/

なお、skip設定の削除および環境変数未設定でのtfstateの保存および
tfstateへのlist,pullで問題なくtfstateに関する情報を取得できていること
の2点は確認済みです。

### ドキュメントの変更は必要ですか？
はい。本PRで実施しています。