### PR TITLE
feat: add origin_guard and strict_rule to sakura_enhanced_lb

### DIFF
--- a/docs/data-sources/enhanced_lb.md
+++ b/docs/data-sources/enhanced_lb.md
@@ -39,6 +39,7 @@ data "sakura_enhanced_lb" "foobar" {
 - `icon_id` (String) The icon id attached to the Enhanced LB
 - `letsencrypt` (Attributes) (see [below for nested schema](#nestedatt--letsencrypt))
 - `monitoring_suite` (Attributes) The monitoring suite settings of the Enhanced LB. (see [below for nested schema](#nestedatt--monitoring_suite))
+- `origin_guard` (Attributes) The origin guard configuration (see [below for nested schema](#nestedatt--origin_guard))
 - `plan` (Number) The plan of the Enhanced LB
 - `proxy_networks` (List of String) A list of CIDR block used by the Enhanced LB to access the server
 - `proxy_protocol` (Boolean) The flag to enable proxy protocol v2
@@ -47,6 +48,7 @@ data "sakura_enhanced_lb" "foobar" {
 - `server` (Attributes List) (see [below for nested schema](#nestedatt--server))
 - `sorry_server` (Attributes) (see [below for nested schema](#nestedatt--sorry_server))
 - `sticky_session` (Boolean) The flag to enable sticky session
+- `strict_rule` (Attributes) The strict rule configuration (see [below for nested schema](#nestedatt--strict_rule))
 - `syslog` (Attributes) (see [below for nested schema](#nestedatt--syslog))
 - `timeout` (Number) The timeout duration in seconds
 - `vip` (String) The virtual IP address assigned to the Enhanced LB
@@ -126,6 +128,14 @@ Read-Only:
 - `enabled` (Boolean) Enable sending signals to Monitoring Suite
 
 
+<a id="nestedatt--origin_guard"></a>
+### Nested Schema for `origin_guard`
+
+Read-Only:
+
+- `token` (String) The token used for origin guard
+
+
 <a id="nestedatt--rule"></a>
 ### Nested Schema for `rule`
 
@@ -166,6 +176,14 @@ Read-Only:
 
 - `ip_address` (String) The IP address of the SorryServer. This will be used when all servers are down
 - `port` (Number) The port number of the SorryServer. This will be used when all servers are down
+
+
+<a id="nestedatt--strict_rule"></a>
+### Nested Schema for `strict_rule`
+
+Read-Only:
+
+- `enabled` (Boolean) The flag to enable strict rule
 
 
 <a id="nestedatt--syslog"></a>

--- a/docs/resources/enhanced_lb.md
+++ b/docs/resources/enhanced_lb.md
@@ -40,6 +40,14 @@ resource "sakura_enhanced_lb" "foobar" {
     port   = 514
   }
 
+  origin_guard = {
+    token = "exampletoken"
+  }
+
+  strict_rule = {
+    enabled = true
+  }
+
   bind_port = [{
     proxy_mode = "http"
     port       = 80
@@ -113,6 +121,7 @@ resource "sakura_server" "foobar" {
 - `gzip` (Boolean) The flag to enable gzip compression
 - `icon_id` (String) The icon id to attach to the Enhanced LB
 - `monitoring_suite` (Attributes) The monitoring suite settings of the Enhanced LB. (see [below for nested schema](#nestedatt--monitoring_suite))
+- `origin_guard` (Attributes) The origin guard configuration (see [below for nested schema](#nestedatt--origin_guard))
 - `plan` (Number) The plan name of the Enhanced LB. This must be one of [`100`/`500`/`1000`/`5000`/`10000`/`50000`/`100000`/`400000`]
 - `proxy_protocol` (Boolean) The flag to enable proxy protocol v2
 - `region` (String) The name of region that the Enhanced LB is in. This must be one of [`tk1`/`is1`/`anycast`]
@@ -120,6 +129,7 @@ resource "sakura_server" "foobar" {
 - `server` (Attributes List) (see [below for nested schema](#nestedatt--server))
 - `sorry_server` (Attributes) (see [below for nested schema](#nestedatt--sorry_server))
 - `sticky_session` (Boolean) The flag to enable sticky session
+- `strict_rule` (Attributes) The strict rule configuration (see [below for nested schema](#nestedatt--strict_rule))
 - `syslog` (Attributes) (see [below for nested schema](#nestedatt--syslog))
 - `tags` (Set of String) The tags of the Enhanced LB.
 - `timeout` (Number) The timeout duration in seconds
@@ -210,6 +220,14 @@ Optional:
 - `enabled` (Boolean) Enable sending signals to Monitoring Suite
 
 
+<a id="nestedatt--origin_guard"></a>
+### Nested Schema for `origin_guard`
+
+Required:
+
+- `token` (String) The token used for origin guard. This must be between 8 and 32 alphanumeric characters
+
+
 <a id="nestedatt--rule"></a>
 ### Nested Schema for `rule`
 
@@ -253,6 +271,14 @@ Required:
 
 - `ip_address` (String) The IP address of the SorryServer. This will be used when all servers are down
 - `port` (Number) The port number of the SorryServer. This will be used when all servers are down
+
+
+<a id="nestedatt--strict_rule"></a>
+### Nested Schema for `strict_rule`
+
+Required:
+
+- `enabled` (Boolean) The flag to enable strict rule
 
 
 <a id="nestedatt--syslog"></a>

--- a/examples/resources/sakura_enhanced_lb/resource.tf
+++ b/examples/resources/sakura_enhanced_lb/resource.tf
@@ -25,6 +25,14 @@ resource "sakura_enhanced_lb" "foobar" {
     port   = 514
   }
 
+  origin_guard = {
+    token = "exampletoken"
+  }
+
+  strict_rule = {
+    enabled = true
+  }
+
   bind_port = [{
     proxy_mode = "http"
     port       = 80

--- a/go.mod
+++ b/go.mod
@@ -25,8 +25,8 @@ require (
 	github.com/sacloud/cloudhsm-api-go v0.4.0
 	github.com/sacloud/dedicated-storage-api-go v0.2.0
 	github.com/sacloud/eventbus-api-go v0.6.1
-	github.com/sacloud/iaas-api-go v1.28.0
-	github.com/sacloud/iaas-service-go v1.24.0
+	github.com/sacloud/iaas-api-go v1.29.0
+	github.com/sacloud/iaas-service-go v1.25.0
 	github.com/sacloud/iam-api-go v0.3.0
 	github.com/sacloud/kms-api-go v0.4.0
 	github.com/sacloud/monitoring-suite-api-go v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -259,12 +259,12 @@ github.com/sacloud/go-http v0.1.9 h1:Xa5PY8/pb7XWhwG9nAeXSrYXPbtfBWqawgzxD5co3VE
 github.com/sacloud/go-http v0.1.9/go.mod h1:DpDG+MSyxYaBwPJ7l3aKLMzwYdTVtC5Bo63HActcgoE=
 github.com/sacloud/go-otelsetup v0.5.0 h1:L6h65D7i3XAoUdkRAYO7fpjF64gASKt55n0GG5gsub0=
 github.com/sacloud/go-otelsetup v0.5.0/go.mod h1:e9Zt+rFgm0BwG9kVH+QKyfnS9Uxj8mBn4Z8UXkyDWTw=
-github.com/sacloud/iaas-api-go v1.28.0 h1:QBSKrZwy7GivhF+npAU2BAYnKAhq8AGrjNoxmqfNNnc=
-github.com/sacloud/iaas-api-go v1.28.0/go.mod h1:VsW1NC1FPmwRjQRb3npmaOsI2hMtG813HjlomzaLr0U=
+github.com/sacloud/iaas-api-go v1.29.0 h1:ZsgeArFg2PSYfvxiKfJoMkpU7QerSUiclfue9YVtk6c=
+github.com/sacloud/iaas-api-go v1.29.0/go.mod h1:VsW1NC1FPmwRjQRb3npmaOsI2hMtG813HjlomzaLr0U=
 github.com/sacloud/iaas-api-go/trace/otel v0.0.0-20251222225644-7df65ab7d2cf h1:rFe3RKIfJDHw40SzZuixpFLjbdVHIhQqb08KhdsdpCw=
 github.com/sacloud/iaas-api-go/trace/otel v0.0.0-20251222225644-7df65ab7d2cf/go.mod h1:eWB6gHmmot5h4oS9ZWeO3ty1nbF+TmBeiusb43nJHpU=
-github.com/sacloud/iaas-service-go v1.24.0 h1:e2sjgymmIKMqrcQog4Z4CHWHfIWielsyQvI4CpkvgqU=
-github.com/sacloud/iaas-service-go v1.24.0/go.mod h1:vGbJKDeqvbWP96bQCzBg8WQWtiVlmZ30fxqsqk+HMVM=
+github.com/sacloud/iaas-service-go v1.25.0 h1:Oi0V8mD5TIoFdz4RiUc1TaXPi5nqpCnnFhKEmPC/KIo=
+github.com/sacloud/iaas-service-go v1.25.0/go.mod h1:mkASM7bqapHla/AJqL0m3HuGZpSgxpTpLa6HBqoLHos=
 github.com/sacloud/iam-api-go v0.3.0 h1:t7dav2jRnn2DhSg5u9tpyoltFpastnTR/jNZ3OsW6fU=
 github.com/sacloud/iam-api-go v0.3.0/go.mod h1:uKYamf4LfU7gDkWS7MN2xFaiHr4g0DcAOGyr2fNSuL8=
 github.com/sacloud/kms-api-go v0.4.0 h1:F1/Cw7W2h6B/HWsoPDI7xMZkzFKphfVTBOHYh6DT2bM=

--- a/internal/service/enhanced_lb/data_source.go
+++ b/internal/service/enhanced_lb/data_source.go
@@ -84,6 +84,26 @@ func (d *enhancedLBDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 				Computed:    true,
 				Description: desc.Sprintf("The name of region that the Enhanced LB is in. This will be one of [%s]", iaastypes.ProxyLBRegionStrings),
 			},
+			"origin_guard": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "The origin guard configuration",
+				Attributes: map[string]schema.Attribute{
+					"token": schema.StringAttribute{
+						Computed:    true,
+						Description: "The token used for origin guard",
+					},
+				},
+			},
+			"strict_rule": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "The strict rule configuration",
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Computed:    true,
+						Description: "The flag to enable strict rule",
+					},
+				},
+			},
 			"syslog": schema.SingleNestedAttribute{
 				Computed: true,
 				Attributes: map[string]schema.Attribute{

--- a/internal/service/enhanced_lb/model.go
+++ b/internal/service/enhanced_lb/model.go
@@ -35,6 +35,8 @@ type enhancedLBBaseModel struct {
 	VIP                  types.String                `tfsdk:"vip"`
 	ProxyNetworks        types.List                  `tfsdk:"proxy_networks"`
 	MonitoringSuite      types.Object                `tfsdk:"monitoring_suite"`
+	OriginGuard          types.Object                `tfsdk:"origin_guard"`
+	StrictRule           types.Object                `tfsdk:"strict_rule"`
 }
 
 type enhancedLBSyslogModel struct {
@@ -175,6 +177,8 @@ func (model *enhancedLBBaseModel) updateState(ctx context.Context, client *commo
 	model.LetsEncrypt = flattenEnhancedLBACMESetting(data)
 	model.Certificate = flattenEnhancedLBCerts(certs)
 	model.MonitoringSuite = common.FlattenMonitoringSuiteLog(data.MonitoringSuiteLog)
+	model.OriginGuard = flattenEnhancedLBOriginGuard(data)
+	model.StrictRule = flattenEnhancedLBStrictRule(data)
 	if data.IconID.IsEmpty() {
 		model.IconID = types.StringNull()
 	} else {
@@ -343,6 +347,36 @@ func flattenEnhancedLBTimeout(elb *iaas.ProxyLB) int {
 		return elb.Timeout.InactiveSec
 	}
 	return 0
+}
+
+func flattenEnhancedLBOriginGuard(elb *iaas.ProxyLB) types.Object {
+	v := types.ObjectNull(map[string]attr.Type{"token": types.StringType})
+	if elb.OriginGuard != nil {
+		m := map[string]attr.Value{
+			"token": types.StringValue(elb.OriginGuard.Token),
+		}
+		obj, diags := types.ObjectValue(map[string]attr.Type{"token": types.StringType}, m)
+		if diags.HasError() {
+			return v
+		}
+		return obj
+	}
+	return v
+}
+
+func flattenEnhancedLBStrictRule(elb *iaas.ProxyLB) types.Object {
+	v := types.ObjectNull(map[string]attr.Type{"enabled": types.BoolType})
+	if elb.StrictRule != nil {
+		m := map[string]attr.Value{
+			"enabled": types.BoolValue(elb.StrictRule.Enabled),
+		}
+		obj, diags := types.ObjectValue(map[string]attr.Type{"enabled": types.BoolType}, m)
+		if diags.HasError() {
+			return v
+		}
+		return obj
+	}
+	return v
 }
 
 func flattenEnhancedLBACMESetting(elb *iaas.ProxyLB) types.Object {

--- a/internal/service/enhanced_lb/model.go
+++ b/internal/service/enhanced_lb/model.go
@@ -35,8 +35,8 @@ type enhancedLBBaseModel struct {
 	VIP                  types.String                `tfsdk:"vip"`
 	ProxyNetworks        types.List                  `tfsdk:"proxy_networks"`
 	MonitoringSuite      types.Object                `tfsdk:"monitoring_suite"`
-	OriginGuard          types.Object                `tfsdk:"origin_guard"`
-	StrictRule           types.Object                `tfsdk:"strict_rule"`
+	OriginGuard          *enhancedLBOriginGuardModel `tfsdk:"origin_guard"`
+	StrictRule           *enhancedLBStrictRuleModel  `tfsdk:"strict_rule"`
 }
 
 type enhancedLBSyslogModel struct {
@@ -93,6 +93,14 @@ type enhancedLBRuleModel struct {
 	FixedStatusCode              types.String `tfsdk:"fixed_status_code"`
 	FixedContentType             types.String `tfsdk:"fixed_content_type"`
 	FixedMessageBody             types.String `tfsdk:"fixed_message_body"`
+}
+
+type enhancedLBOriginGuardModel struct {
+	Token types.String `tfsdk:"token"`
+}
+
+type enhancedLBStrictRuleModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
 }
 
 type enhancedLBCertificateModel struct {
@@ -349,34 +357,22 @@ func flattenEnhancedLBTimeout(elb *iaas.ProxyLB) int {
 	return 0
 }
 
-func flattenEnhancedLBOriginGuard(elb *iaas.ProxyLB) types.Object {
-	v := types.ObjectNull(map[string]attr.Type{"token": types.StringType})
+func flattenEnhancedLBOriginGuard(elb *iaas.ProxyLB) *enhancedLBOriginGuardModel {
 	if elb.OriginGuard != nil {
-		m := map[string]attr.Value{
-			"token": types.StringValue(elb.OriginGuard.Token),
+		return &enhancedLBOriginGuardModel{
+			Token: types.StringValue(elb.OriginGuard.Token),
 		}
-		obj, diags := types.ObjectValue(map[string]attr.Type{"token": types.StringType}, m)
-		if diags.HasError() {
-			return v
-		}
-		return obj
 	}
-	return v
+	return nil
 }
 
-func flattenEnhancedLBStrictRule(elb *iaas.ProxyLB) types.Object {
-	v := types.ObjectNull(map[string]attr.Type{"enabled": types.BoolType})
+func flattenEnhancedLBStrictRule(elb *iaas.ProxyLB) *enhancedLBStrictRuleModel {
 	if elb.StrictRule != nil {
-		m := map[string]attr.Value{
-			"enabled": types.BoolValue(elb.StrictRule.Enabled),
+		return &enhancedLBStrictRuleModel{
+			Enabled: types.BoolValue(elb.StrictRule.Enabled),
 		}
-		obj, diags := types.ObjectValue(map[string]attr.Type{"enabled": types.BoolType}, m)
-		if diags.HasError() {
-			return v
-		}
-		return obj
 	}
-	return v
+	return nil
 }
 
 func flattenEnhancedLBACMESetting(elb *iaas.ProxyLB) types.Object {

--- a/internal/service/enhanced_lb/resource.go
+++ b/internal/service/enhanced_lb/resource.go
@@ -6,6 +6,7 @@ package enhanced_lb
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
@@ -132,6 +133,32 @@ func (r *enhancedLBResource) Schema(ctx context.Context, _ resource.SchemaReques
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+			},
+			"origin_guard": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "The origin guard configuration",
+				Attributes: map[string]schema.Attribute{
+					"token": schema.StringAttribute{
+						Required:    true,
+						Description: "The token used for origin guard. This must be between 8 and 32 alphanumeric characters",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^[a-zA-Z0-9]{8,32}$`),
+								"must be between 8 and 32 alphanumeric characters",
+							),
+						},
+					},
+				},
+			},
+			"strict_rule": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "The strict rule configuration",
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Required:    true,
+						Description: "The flag to enable strict rule",
+					},
 				},
 			},
 			"syslog": schema.SingleNestedAttribute{

--- a/internal/service/enhanced_lb/resource_test.go
+++ b/internal/service/enhanced_lb/resource_test.go
@@ -100,6 +100,8 @@ func TestAccSakuraEnhancedLB_basic(t *testing.T) {
 						"sakura_icon.foobar", "id",
 					),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_suite.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "origin_guard.token", "abcdefgh"),
+					resource.TestCheckResourceAttr(resourceName, "strict_rule.enabled", "true"),
 				),
 			},
 			{
@@ -152,6 +154,8 @@ func TestAccSakuraEnhancedLB_basic(t *testing.T) {
 						"sakura_server.foobar", "ip_address",
 					),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_suite.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "origin_guard.token", "ijklmnop"),
+					resource.TestCheckResourceAttr(resourceName, "strict_rule.enabled", "false"),
 				),
 			},
 		},
@@ -244,6 +248,8 @@ func TestAccImportSakuraEnhancedLB_basic(t *testing.T) {
 			"rule.0.path":              "/",
 			"rule.0.group":             "group1",
 			"monitoring_suite.enabled": "true",
+			"origin_guard.token":       "abcdefgh",
+			"strict_rule.enabled":      "true",
 		}
 
 		if err := test.CompareStateMulti(s[0], expects); err != nil {
@@ -333,6 +339,14 @@ resource "sakura_enhanced_lb" "foobar" {
     request_header_value_not_match = true
   }]
 
+  origin_guard = {
+    token = "abcdefgh"
+  }
+
+  strict_rule = {
+    enabled = true
+  }
+
   monitoring_suite = {
     enabled = true
   }
@@ -393,6 +407,14 @@ resource "sakura_enhanced_lb" "foobar" {
     redirect_location    = "https://redirect.usacloud.jp"
   }]
 
+  origin_guard = {
+    token = "ijklmnop"
+  }
+
+  strict_rule = {
+    enabled = false
+  }
+
   monitoring_suite = {
     enabled = false
   }
@@ -441,6 +463,14 @@ resource "sakura_enhanced_lb" "foobar" {
     source_ips = "192.0.2.1,192.0.2.2"
     group      = "group1"
   }]
+
+  origin_guard = {
+    token = "abcdefgh"
+  }
+
+  strict_rule = {
+    enabled = true
+  }
 
   monitoring_suite = {
     enabled = true

--- a/internal/service/enhanced_lb/structure.go
+++ b/internal/service/enhanced_lb/structure.go
@@ -230,6 +230,7 @@ func expandEnhancedLBRules(model *enhancedLBResourceModel) []*iaas.ProxyLBRule {
 				RequestHeaderValueNotMatch:   rule.RequestHeaderValueNotMatch.ValueBool(),
 				ServerGroup:                  rule.Group.ValueString(),
 				Action:                       iaastypes.EProxyLBRuleAction(rule.Action.ValueString()),
+				RedirectLocation:             rule.RedirectLocation.ValueString(),
 				RedirectStatusCode:           iaastypes.EProxyLBRedirectStatusCode(utils.MustAtoI(rule.RedirectStatusCode.ValueString())),
 				FixedStatusCode:              iaastypes.EProxyLBFixedStatusCode(utils.MustAtoI(rule.FixedStatusCode.ValueString())),
 				FixedContentType:             iaastypes.EProxyLBFixedContentType(rule.FixedContentType.ValueString()),

--- a/internal/service/enhanced_lb/structure.go
+++ b/internal/service/enhanced_lb/structure.go
@@ -6,7 +6,6 @@ package enhanced_lb
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/sacloud/iaas-api-go"
 	iaastypes "github.com/sacloud/iaas-api-go/types"
@@ -66,30 +65,18 @@ func expandEnhancedLBUpdateRequest(model, state *enhancedLBResourceModel) *iaas.
 }
 
 func expandEnhancedLBOriginGuard(model *enhancedLBResourceModel) *iaas.ProxyLBOriginGuard {
-	if !model.OriginGuard.IsNull() && !model.OriginGuard.IsUnknown() {
-		var m struct {
-			Token types.String `tfsdk:"token"`
-		}
-		diags := model.OriginGuard.As(context.Background(), &m, basetypes.ObjectAsOptions{})
-		if !diags.HasError() {
-			return &iaas.ProxyLBOriginGuard{
-				Token: m.Token.ValueString(),
-			}
+	if model.OriginGuard != nil {
+		return &iaas.ProxyLBOriginGuard{
+			Token: model.OriginGuard.Token.ValueString(),
 		}
 	}
 	return nil
 }
 
 func expandEnhancedLBStrictRule(model *enhancedLBResourceModel) *iaas.ProxyLBStrictRule {
-	if !model.StrictRule.IsNull() && !model.StrictRule.IsUnknown() {
-		var m struct {
-			Enabled types.Bool `tfsdk:"enabled"`
-		}
-		diags := model.StrictRule.As(context.Background(), &m, basetypes.ObjectAsOptions{})
-		if !diags.HasError() {
-			return &iaas.ProxyLBStrictRule{
-				Enabled: m.Enabled.ValueBool(),
-			}
+	if model.StrictRule != nil {
+		return &iaas.ProxyLBStrictRule{
+			Enabled: model.StrictRule.Enabled.ValueBool(),
 		}
 	}
 	return nil

--- a/internal/service/enhanced_lb/structure.go
+++ b/internal/service/enhanced_lb/structure.go
@@ -6,16 +6,17 @@ package enhanced_lb
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/sacloud/iaas-api-go"
-	"github.com/sacloud/iaas-api-go/types"
+	iaastypes "github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/terraform-provider-sakura/internal/common"
 	"github.com/sacloud/terraform-provider-sakura/internal/common/utils"
 )
 
 func expandEnhancedLBCreateRequest(model *enhancedLBResourceModel) *iaas.ProxyLBCreateRequest {
 	return &iaas.ProxyLBCreateRequest{
-		Plan:                 types.EProxyLBPlan(model.Plan.ValueInt64()),
+		Plan:                 iaastypes.EProxyLBPlan(model.Plan.ValueInt64()),
 		HealthCheck:          expandEnhancedLBHealthCheck(model),
 		SorryServer:          expandEnhancedLBSorryServer(model),
 		BindPorts:            expandEnhancedLBBindPorts(model),
@@ -28,12 +29,14 @@ func expandEnhancedLBCreateRequest(model *enhancedLBResourceModel) *iaas.ProxyLB
 		Syslog:               expandEnhancedLBSyslog(model),
 		Timeout:              expandEnhancedLBTimeout(model),
 		UseVIPFailover:       model.VIPFailover.ValueBool(),
-		Region:               types.EProxyLBRegion(model.Region.ValueString()),
+		Region:               iaastypes.EProxyLBRegion(model.Region.ValueString()),
 		Name:                 model.Name.ValueString(),
 		Description:          model.Description.ValueString(),
 		Tags:                 common.TsetToStrings(model.Tags),
 		IconID:               common.ExpandSakuraCloudID(model.IconID),
 		MonitoringSuiteLog:   common.ExpandMonitoringSuiteLog(model.MonitoringSuite),
+		OriginGuard:          expandEnhancedLBOriginGuard(model),
+		StrictRule:           expandEnhancedLBStrictRule(model),
 		// LetsEncryptフィールドはenhanced_lb_acmeで管理するためCreate時には設定しない
 	}
 }
@@ -57,7 +60,39 @@ func expandEnhancedLBUpdateRequest(model, state *enhancedLBResourceModel) *iaas.
 		Tags:                 common.TsetToStrings(model.Tags),
 		IconID:               common.ExpandSakuraCloudID(model.IconID),
 		MonitoringSuiteLog:   common.ExpandMonitoringSuiteLog(model.MonitoringSuite),
+		OriginGuard:          expandEnhancedLBOriginGuard(model),
+		StrictRule:           expandEnhancedLBStrictRule(model),
 	}
+}
+
+func expandEnhancedLBOriginGuard(model *enhancedLBResourceModel) *iaas.ProxyLBOriginGuard {
+	if !model.OriginGuard.IsNull() && !model.OriginGuard.IsUnknown() {
+		var m struct {
+			Token types.String `tfsdk:"token"`
+		}
+		diags := model.OriginGuard.As(context.Background(), &m, basetypes.ObjectAsOptions{})
+		if !diags.HasError() {
+			return &iaas.ProxyLBOriginGuard{
+				Token: m.Token.ValueString(),
+			}
+		}
+	}
+	return nil
+}
+
+func expandEnhancedLBStrictRule(model *enhancedLBResourceModel) *iaas.ProxyLBStrictRule {
+	if !model.StrictRule.IsNull() && !model.StrictRule.IsUnknown() {
+		var m struct {
+			Enabled types.Bool `tfsdk:"enabled"`
+		}
+		diags := model.StrictRule.As(context.Background(), &m, basetypes.ObjectAsOptions{})
+		if !diags.HasError() {
+			return &iaas.ProxyLBStrictRule{
+				Enabled: m.Enabled.ValueBool(),
+			}
+		}
+	}
+	return nil
 }
 
 func expandEnhancedLBStickySession(model *enhancedLBResourceModel) *iaas.ProxyLBStickySession {
@@ -82,11 +117,11 @@ func expandEnhancedLBGzip(model *enhancedLBResourceModel) *iaas.ProxyLBGzip {
 func expandEnhancedLBBackendHttpKeepAlive(model *enhancedLBResourceModel) *iaas.ProxyLBBackendHttpKeepAlive {
 	s := model.BackendHttpKeepAlive.ValueString()
 	if s == "" {
-		s = types.ProxyLBBackendHttpKeepAlive.Safe.String()
+		s = iaastypes.ProxyLBBackendHttpKeepAlive.Safe.String()
 	}
 
 	return &iaas.ProxyLBBackendHttpKeepAlive{
-		Mode: types.EProxyLBBackendHttpKeepAlive(s),
+		Mode: iaastypes.EProxyLBBackendHttpKeepAlive(s),
 	}
 }
 
@@ -123,7 +158,7 @@ func expandEnhancedLBBindPorts(model *enhancedLBResourceModel) []*iaas.ProxyLBBi
 		}
 
 		results = append(results, &iaas.ProxyLBBindPort{
-			ProxyMode:         types.EProxyLBProxyMode(bindPort.ProxyMode.ValueString()),
+			ProxyMode:         iaastypes.EProxyLBProxyMode(bindPort.ProxyMode.ValueString()),
 			Port:              int(bindPort.Port.ValueInt32()),
 			RedirectToHTTPS:   bindPort.RedirectToHTTPS.ValueBool(),
 			SupportHTTP2:      bindPort.SupportHTTP2.ValueBool(),
@@ -140,14 +175,14 @@ func expandEnhancedLBHealthCheck(model *enhancedLBResourceModel) *iaas.ProxyLBHe
 		switch protocol {
 		case "http":
 			return &iaas.ProxyLBHealthCheck{
-				Protocol:  types.ProxyLBProtocols.HTTP,
+				Protocol:  iaastypes.ProxyLBProtocols.HTTP,
 				Path:      model.HealthCheck.Path.ValueString(),
 				Host:      model.HealthCheck.HostHeader.ValueString(),
 				DelayLoop: int(model.HealthCheck.DelayLoop.ValueInt64()),
 			}
 		case "tcp":
 			return &iaas.ProxyLBHealthCheck{
-				Protocol:  types.ProxyLBProtocols.TCP,
+				Protocol:  iaastypes.ProxyLBProtocols.TCP,
 				DelayLoop: int(model.HealthCheck.DelayLoop.ValueInt64()),
 			}
 		}
@@ -194,11 +229,10 @@ func expandEnhancedLBRules(model *enhancedLBResourceModel) []*iaas.ProxyLBRule {
 				RequestHeaderValueIgnoreCase: rule.RequestHeaderValueIgnoreCase.ValueBool(),
 				RequestHeaderValueNotMatch:   rule.RequestHeaderValueNotMatch.ValueBool(),
 				ServerGroup:                  rule.Group.ValueString(),
-				Action:                       types.EProxyLBRuleAction(rule.Action.ValueString()),
-				RedirectLocation:             rule.RedirectLocation.ValueString(),
-				RedirectStatusCode:           types.EProxyLBRedirectStatusCode(utils.MustAtoI(rule.RedirectStatusCode.ValueString())),
-				FixedStatusCode:              types.EProxyLBFixedStatusCode(utils.MustAtoI(rule.FixedStatusCode.ValueString())),
-				FixedContentType:             types.EProxyLBFixedContentType(rule.FixedContentType.ValueString()),
+				Action:                       iaastypes.EProxyLBRuleAction(rule.Action.ValueString()),
+				RedirectStatusCode:           iaastypes.EProxyLBRedirectStatusCode(utils.MustAtoI(rule.RedirectStatusCode.ValueString())),
+				FixedStatusCode:              iaastypes.EProxyLBFixedStatusCode(utils.MustAtoI(rule.FixedStatusCode.ValueString())),
+				FixedContentType:             iaastypes.EProxyLBFixedContentType(rule.FixedContentType.ValueString()),
 				FixedMessageBody:             rule.FixedMessageBody.ValueString(),
 			})
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

iaas-service-go v1.25.0 (および iaas-api-go v1.29.0) の変更を取り込み、
`sakura_enhanced_lb` リソース・データソースに `origin_guard` と `strict_rule` 属性を追加した。

- `origin_guard`: OriginGuard 設定（`token`: 半角英数 8〜32 文字）
- `strict_rule`: StrictRule 設定（`enabled`: bool）

また、ルールの中の `RedirectLocation`がAPIリクエストに含まれないという問題を見つけたので合わせて修正しています。

### ドキュメントの変更は必要ですか？

不要（`make generate-docs` で自動生成済み）