### PR TITLE
Sensitiveフィールドの扱いを改善

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -129,6 +129,11 @@ timeouts = {
 }
 ```
 
+### WriteOnlyの活用
+
+リソースの中には`password`/`password_wo`等同じパラメータに対してSensitive/WriteOnlyに分かれた名前が2つ提供されている属性があります。これらに関してはWriteOnlyバージョンの属性を優先して使ってください。Sensitiveの方は互換性のために残しており、将来削除される可能性があります。
+これらの属性は現在APIが値を返しているものもありますが、将来的にはAPIから取得できなくなる設定となっており、WriteOnlyでtfstateに残さないようにするのが適切なものとなっています。
+
 ### apprun_shared
 
 v3.1.0からwrite-only版の`password_wo`/`password_wo_version`が提供されました。今後はこちらを利用してください。
@@ -686,6 +691,8 @@ resource "sakura_dns_record" "record2" {
 `switch_id`フィールドは`vswitch_id`に変更されました。
 
 ### local_router
+
+将来的に`secret_keys`属性は値を持たなくなります。依存した処理をしないようにしてください。
 
 `switch` / `network_interface`フィールドがBlockからSingle型のAttributeに変更されたため、下記のように書き換える必要があります。
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ v3 における変更点は [CHANGES.md](./CHANGES.md) をご覧ください。
 以下のリソースは未移植です。必要な場合はv2との併用を検討してください。
 
 - archive_share
-- cdrom
 - certificate_authority
 - esme
 - mobile_gateway

--- a/docs/data-sources/container_registry.md
+++ b/docs/data-sources/container_registry.md
@@ -34,7 +34,7 @@ data "sakura_container_registry" "foobar" {
 - `fqdn` (String) The FQDN for accessing the Container Registry. FQDN is built from `subdomain_label` + `.sakuracr.jp`
 - `icon_id` (String) The icon id attached to the Container Registry
 - `subdomain_label` (String) The label at the lowest of the FQDN used when be accessed from users
-- `user` (Attributes Set) (see [below for nested schema](#nestedatt--user))
+- `user` (Attributes List) (see [below for nested schema](#nestedatt--user))
 - `virtual_domain` (String) The alias for accessing the Container Registry
 
 <a id="nestedatt--user"></a>

--- a/docs/resources/archive.md
+++ b/docs/resources/archive.md
@@ -52,6 +52,8 @@ resource "sakura_archive" "foobar" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `archive_file` (String) The file path to upload to the SakuraCloud Archive.
 - `description` (String) The description of the Archive. The length of this value must be in the range [`1`-`512`]
 - `hash` (String) The md5 checksum calculated from the base64 encoded file body
@@ -61,6 +63,8 @@ resource "sakura_archive" "foobar" {
 - `source_archive_zone` (String) The share key of source shared archive
 - `source_disk_id` (String) The id of the source disk. This conflicts with [`source_archive_id`]
 - `source_shared_key` (String, Sensitive) The share key of source shared archive
+- `source_shared_key_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The share key of source shared archive
+- `source_shared_key_wo_version` (Number) The version of the source_shared_key_wo field. This value must be greater than 0 when set. Increment this when changing source_shared_key_wo.
 - `tags` (Set of String) The tags of the Archive.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `zone` (String) The name of zone that the Archive will be created (e.g. `is1a`, `tk1a`)

--- a/docs/resources/cloudhsm_peer.md
+++ b/docs/resources/cloudhsm_peer.md
@@ -32,10 +32,13 @@ resource "sakura_cloudhsm_peer" "foobar" {
 
 - `cloudhsm_id` (String) The ID of the CloudHSM to associate with the peer
 - `router_id` (String) The router ID to associate with the peer
-- `secret_key` (String, Sensitive) The secret key for the CloudHSM Peer
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
+- `secret_key` (String, Sensitive) The secret key for the CloudHSM Peer.
+- `secret_key_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The secret key for the CloudHSM Peer
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `zone` (String) The zone of the CloudHSM Peer. This must be one of [`is1b`/`tk1a`]
 

--- a/docs/resources/container_registry.md
+++ b/docs/resources/container_registry.md
@@ -67,7 +67,7 @@ resource "sakura_container_registry" "foobar" {
 - `icon_id` (String) The icon id to attach to the Container Registry
 - `tags` (Set of String) The tags of the Container Registry.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
-- `user` (Attributes Set) User accounts for accessing the Container Registry (see [below for nested schema](#nestedatt--user))
+- `user` (Attributes List) User accounts for accessing the Container Registry (see [below for nested schema](#nestedatt--user))
 - `virtual_domain` (String) The alias for accessing the Container Registry
 
 ### Read-Only
@@ -91,5 +91,10 @@ Optional:
 Required:
 
 - `name` (String) The user name used to authenticate remote access
-- `password` (String, Sensitive) The password used to authenticate remote access
 - `permission` (String) The level of access that allow to the user. This must be one of [`all`/`readwrite`/`readonly`]
+
+Optional:
+
+- `password` (String, Sensitive) The password used to authenticate remote access
+- `password_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The password used to authenticate remote access
+- `password_wo_version` (Number) The version of the password_wo field. This value must be greater than 0 when set. Increment this when changing password.

--- a/docs/resources/kms.md
+++ b/docs/resources/kms.md
@@ -31,9 +31,12 @@ resource "sakura_kms" "foobar" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `description` (String) The description of the KMS key. The length of this value must be in the range [`1`-`512`]
 - `key_origin` (String) Key origin of the KMS key. 'generated' or 'imported'. Default is 'generated'.
 - `plain_key` (String, Sensitive) Plain key for imported KMS key. Required when `key_origin` is 'imported'.
+- `plain_key_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Plain key for imported KMS key. Required when `key_origin` is 'imported'.
 - `rotate_version` (Number) The rotateion version. This number is incremented when you want rotate KMS key.
 - `schedule_destruction_days` (Number) The number of days to schedule the destruction of the KMS key. If set, the KMS key will be scheduled for destruction after the specified number of days instead of immediate destruction in 'terraform destroy'.
 - `status` (String) The status of the KMS key.

--- a/docs/resources/local_router.md
+++ b/docs/resources/local_router.md
@@ -111,12 +111,14 @@ Optional:
 Required:
 
 - `peer_id` (String) The ID of the peer LocalRouter
-- `secret_key` (String, Sensitive) The secret key of the peer LocalRouter
 
 Optional:
 
 - `description` (String) The description of the Local Router Peer. The length of this value must be in the range [`1`-`512`]
 - `enabled` (Boolean) The flag to enable the LocalRouter
+- `secret_key` (String, Sensitive) The secret key of the peer LocalRouter
+- `secret_key_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The secret key of the peer LocalRouter
+- `secret_key_wo_version` (Number) The version of the secret_key_wo field. This value must be greater than 0 when set. Increment this when changing secret_key_wo.
 
 
 <a id="nestedatt--static_route"></a>

--- a/docs/resources/vpn_router.md
+++ b/docs/resources/vpn_router.md
@@ -289,9 +289,14 @@ Optional:
 
 Required:
 
-- `pre_shared_secret` (String, Sensitive) The pre shared secret for L2TP/IPsec
 - `range_start` (String) The start value of IP address range to assign to L2TP/IPsec client
 - `range_stop` (String) The end value of IP address range to assign to L2TP/IPsec client
+
+Optional:
+
+- `pre_shared_secret` (String, Sensitive) The pre shared secret for L2TP/IPsec
+- `pre_shared_secret_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The pre shared secret for L2TP/IPsec
+- `pre_shared_secret_wo_version` (Number) The version of the pre_shared_secret_wo field. This value must be greater than 0 when set. Increment this when changing pre_shared_secret_wo.
 
 
 <a id="nestedatt--monitoring_suite"></a>
@@ -369,9 +374,14 @@ Required:
 
 - `local_prefix` (List of String) A list of CIDR block of the network under the VPN Router
 - `peer` (String) The IP address of the opposing appliance connected to the VPN Router
-- `pre_shared_secret` (String, Sensitive) The pre shared secret for the VPN. The length of this value must be in the range [`0`-`40`]
 - `remote_id` (String) The id of the opposing appliance connected to the VPN Router. This is typically set same as value of `peer`
 - `routes` (List of String) A list of CIDR block of VPN connected networks
+
+Optional:
+
+- `pre_shared_secret` (String, Sensitive) The pre shared secret for the VPN. The length of this value must be in the range [`0`-`40`]
+- `pre_shared_secret_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The pre shared secret for the VPN. The length of this value must be in the range [`0`-`40`]
+- `pre_shared_secret_wo_version` (Number) The version of the pre_shared_secret_wo field. This value must be greater than 0 when set. Increment this when changing pre_shared_secret_wo.
 
 
 <a id="nestedatt--site_to_site_vpn_parameter"></a>

--- a/internal/service/archive/resource.go
+++ b/internal/service/archive/resource.go
@@ -61,16 +61,18 @@ func (r *archiveResource) Configure(ctx context.Context, req resource.ConfigureR
 
 type archiveResourceModel struct {
 	common.SakuraBaseModel
-	Zone              types.String   `tfsdk:"zone"`
-	Size              types.Int32    `tfsdk:"size"`
-	Hash              types.String   `tfsdk:"hash"`
-	IconID            types.String   `tfsdk:"icon_id"`
-	ArchiveFile       types.String   `tfsdk:"archive_file"`
-	SourceDiskID      types.String   `tfsdk:"source_disk_id"`
-	SourceSharedKey   types.String   `tfsdk:"source_shared_key"`
-	SourceArchiveID   types.String   `tfsdk:"source_archive_id"`
-	SourceArchiveZone types.String   `tfsdk:"source_archive_zone"`
-	Timeouts          timeouts.Value `tfsdk:"timeouts"`
+	Zone                     types.String   `tfsdk:"zone"`
+	Size                     types.Int32    `tfsdk:"size"`
+	Hash                     types.String   `tfsdk:"hash"`
+	IconID                   types.String   `tfsdk:"icon_id"`
+	ArchiveFile              types.String   `tfsdk:"archive_file"`
+	SourceDiskID             types.String   `tfsdk:"source_disk_id"`
+	SourceSharedKey          types.String   `tfsdk:"source_shared_key"`
+	SourceSharedKeyWO        types.String   `tfsdk:"source_shared_key_wo"`
+	SourceSharedKeyWOVersion types.Int32    `tfsdk:"source_shared_key_wo_version"`
+	SourceArchiveID          types.String   `tfsdk:"source_archive_id"`
+	SourceArchiveZone        types.String   `tfsdk:"source_archive_zone"`
+	Timeouts                 timeouts.Value `tfsdk:"timeouts"`
 }
 
 func (r *archiveResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -162,10 +164,36 @@ func (r *archiveResource) Schema(ctx context.Context, req resource.SchemaRequest
 						}
 						return nil
 					}),
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("source_shared_key_wo")),
+					stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("source_shared_key_wo")),
 					stringvalidator.ConflictsWith(sizePath, sourceArchiveIdPath, sourceArchiveZonePath, sourceDiskIdPath),
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+			},
+			"source_shared_key_wo": schema.StringAttribute{
+				Optional:    true,
+				WriteOnly:   true,
+				Description: "The share key of source shared archive",
+				Validators: []validator.String{
+					sacloudvalidator.StringFuncValidator(func(v string) error {
+						key := iaastypes.ArchiveShareKey(v)
+						if !key.ValidFormat() {
+							return fmt.Errorf("%q must be formatted in '<ZONE>:<ID>:<TOKEN>'", key)
+						}
+						return nil
+					}),
+					stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("source_shared_key")),
+					stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("source_shared_key_wo_version")),
+				},
+			},
+			"source_shared_key_wo_version": schema.Int32Attribute{
+				Optional:    true,
+				Description: "The version of the source_shared_key_wo field. This value must be greater than 0 when set. Increment this when changing source_shared_key_wo.",
+				Validators: []validator.Int32{
+					int32validator.AtLeast(1),
+					int32validator.AlsoRequires(path.MatchRelative().AtParent().AtName("source_shared_key_wo")),
 				},
 			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
@@ -181,8 +209,9 @@ func (r *archiveResource) ImportState(ctx context.Context, req resource.ImportSt
 }
 
 func (r *archiveResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan archiveResourceModel
+	var plan, config archiveResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -195,7 +224,7 @@ func (r *archiveResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	builder, cleanup, err := expandArchiveBuilder(&plan, zone, r.client)
+	builder, cleanup, err := expandArchiveBuilder(&plan, &config, zone, r.client)
 	if err != nil {
 		resp.Diagnostics.AddError("Create: Expand Builder Error", err.Error())
 		return
@@ -299,7 +328,9 @@ func (model *archiveResourceModel) updateState(archive *iaas.Archive, zone strin
 	model.Hash = types.StringValue(expandArchiveHash(model))
 	model.SourceArchiveID = types.StringValue(model.SourceArchiveID.ValueString())
 	model.SourceDiskID = types.StringValue(model.SourceDiskID.ValueString())
-	model.SourceSharedKey = types.StringValue(model.SourceSharedKey.ValueString())
+	if !utils.IsKnown(model.SourceSharedKey) {
+		model.SourceSharedKey = types.StringNull()
+	}
 	if archive.IconID.IsEmpty() {
 		model.IconID = types.StringNull()
 	} else {
@@ -322,7 +353,7 @@ func getArchive(ctx context.Context, client *common.APIClient, id iaastypes.ID, 
 	return archive
 }
 
-func expandArchiveBuilder(d *archiveResourceModel, zone string, client *common.APIClient) (archiveUtil.Builder, func(), error) {
+func expandArchiveBuilder(d, config *archiveResourceModel, zone string, client *common.APIClient) (archiveUtil.Builder, func(), error) {
 	var reader io.ReadCloser
 	source := d.ArchiveFile.ValueString()
 	if source != "" {
@@ -353,6 +384,11 @@ func expandArchiveBuilder(d *archiveResourceModel, zone string, client *common.A
 
 	// Note: APIとしてはディスクやアーカイブをソースとした場合Sizeの指定はできないが、
 	//       archiveUtil.Director側でAPIに渡すパラメータを制御しているためここでは常に渡して問題ない
+	sourceSharedKey := d.SourceSharedKey.ValueString()
+	if config != nil && config.SourceSharedKeyWO.ValueString() != "" {
+		sourceSharedKey = config.SourceSharedKeyWO.ValueString()
+	}
+
 	director := &archiveUtil.Director{
 		Name:              d.Name.ValueString(),
 		Description:       d.Description.ValueString(),
@@ -363,7 +399,7 @@ func expandArchiveBuilder(d *archiveResourceModel, zone string, client *common.A
 		SourceDiskID:      common.ExpandSakuraCloudID(d.SourceDiskID),
 		SourceArchiveID:   common.ExpandSakuraCloudID(d.SourceArchiveID),
 		SourceArchiveZone: sourceArchiveZone,
-		SourceSharedKey:   iaastypes.ArchiveShareKey(d.SourceSharedKey.ValueString()),
+		SourceSharedKey:   iaastypes.ArchiveShareKey(sourceSharedKey),
 		Client:            archiveUtil.NewAPIClient(client),
 	}
 	return director.Builder(), func() {

--- a/internal/service/archive/resource_test.go
+++ b/internal/service/archive/resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -125,12 +126,13 @@ func TestAccSakuraArchive_transfer(t *testing.T) {
 	})
 }
 
-/*
 func TestAccSakuraArchive_fromShared(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
+	test.SkipIfEnvIsNotSet(t, "SAKURA_ARCHIVE_SHARE_KEY")
 
 	resourceName := "sakura_archive.foobar"
 	rand := test.RandomName()
+	key := os.Getenv("SAKURA_ARCHIVE_SHARE_KEY")
 
 	var archive iaas.Archive
 	resource.Test(t, resource.TestCase{
@@ -142,7 +144,7 @@ func TestAccSakuraArchive_fromShared(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraArchive_fromShared, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraArchive_fromShared, rand, key),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraArchiveExists(resourceName, &archive),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
@@ -150,14 +152,14 @@ func TestAccSakuraArchive_fromShared(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2"),
-					resource.TestCheckResourceAttrPair(resourceName, "source_shared_key",
-						"sakura_archive_share.share", "share_key"),
+					resource.TestCheckNoResourceAttr(resourceName, "source_shared_key"),
+					resource.TestCheckNoResourceAttr(resourceName, "source_shared_key_wo"),
+					resource.TestCheckResourceAttr(resourceName, "source_shared_key_wo_version", "1"),
 				),
 			},
 		},
 	})
 }
-*/
 
 func testCheckSakuraArchiveExists(n string, archive *iaas.Archive) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -312,30 +314,15 @@ resource "sakura_archive" "foobar" {
 }
 `
 
-/*
 var testAccSakuraArchive_fromShared = `
-resource "sakura_archive" "source" {
-  name         = "{{ .arg0 }}"
-  size         = 20
-  archive_file = "test/dummy.raw"
-
-  zone = "is1a"
-}
-
-resource "sakura_archive_share" "share" {
-  archive_id = sakura_archive.source.id
-
-  zone = "is1a"
-}
-
 resource "sakura_archive" "foobar" {
   name        = "{{ .arg0 }}"
   description = "description"
   tags        = ["tag1", "tag2"]
 
-  source_shared_key = sakura_archive_share.share.share_key
+  source_shared_key_wo = "{{ .arg1 }}"
+  source_shared_key_wo_version = 1
 
   zone = "is1b"
 }
 `
-*/

--- a/internal/service/cloudhsm/resource_peer.go
+++ b/internal/service/cloudhsm/resource_peer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -49,9 +50,10 @@ func (r *cloudHSMPeerResource) Configure(ctx context.Context, req resource.Confi
 
 type cloudHSMPeerResourceModel struct {
 	cloudHSMPeerBaseModel
-	RouterID  types.String   `tfsdk:"router_id"`
-	SecretKey types.String   `tfsdk:"secret_key"`
-	Timeouts  timeouts.Value `tfsdk:"timeouts"`
+	RouterID    types.String   `tfsdk:"router_id"`
+	SecretKey   types.String   `tfsdk:"secret_key"`
+	SecretKeyWO types.String   `tfsdk:"secret_key_wo"`
+	Timeouts    timeouts.Value `tfsdk:"timeouts"`
 }
 
 func (r *cloudHSMPeerResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -71,9 +73,21 @@ func (r *cloudHSMPeerResource) Schema(ctx context.Context, _ resource.SchemaRequ
 				Description: "The router ID to associate with the peer",
 			},
 			"secret_key": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Sensitive:   true,
+				Description: "The secret key for the CloudHSM Peer.",
+				Validators: []validator.String{
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("secret_key_wo")),
+					stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("secret_key_wo")),
+				},
+			},
+			"secret_key_wo": schema.StringAttribute{
+				Optional:    true,
+				WriteOnly:   true,
 				Description: "The secret key for the CloudHSM Peer",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("secret_key")),
+				},
 			},
 			"index": schema.Int64Attribute{
 				Computed:    true,
@@ -101,8 +115,9 @@ func (r *cloudHSMPeerResource) ImportState(ctx context.Context, req resource.Imp
 }
 
 func (r *cloudHSMPeerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan cloudHSMPeerResourceModel
+	var plan, config cloudHSMPeerResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -123,9 +138,18 @@ func (r *cloudHSMPeerResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	secretKey := plan.SecretKey.ValueString()
+	if config.SecretKeyWO.ValueString() != "" {
+		secretKey = config.SecretKeyWO.ValueString()
+	}
+	if secretKey == "" {
+		resp.Diagnostics.AddError("Create: Attribute Error", "either secret_key or secret_key_wo must be provided")
+		return
+	}
+
 	err = peerOp.Create(ctx, cloudhsm.CloudHSMPeerCreateParams{
 		RouterID:  plan.RouterID.ValueString(),
-		SecretKey: plan.SecretKey.ValueString(),
+		SecretKey: secretKey,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to create CloudHSM Peer: %s", err))

--- a/internal/service/container_registry/data_source.go
+++ b/internal/service/container_registry/data_source.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/terraform-provider-sakura/internal/common"
 )
@@ -39,6 +40,13 @@ func (d *containerRegistryDataSource) Configure(ctx context.Context, req datasou
 
 type containerRegistryDataSourceModel struct {
 	containerRegistryBaseModel
+	User []*containerRegistryUserDSModel `tfsdk:"user"`
+}
+
+type containerRegistryUserDSModel struct {
+	Name       types.String `tfsdk:"name"`
+	Password   types.String `tfsdk:"password"`
+	Permission types.String `tfsdk:"permission"`
 }
 
 func (d *containerRegistryDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -65,7 +73,7 @@ func (d *containerRegistryDataSource) Schema(_ context.Context, _ datasource.Sch
 				Computed:    true,
 				Description: "The FQDN for accessing the Container Registry. FQDN is built from `subdomain_label` + `.sakuracr.jp`",
 			},
-			"user": schema.SetNestedAttribute{
+			"user": schema.ListNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -109,6 +117,20 @@ func (d *containerRegistryDataSource) Read(ctx context.Context, req datasource.R
 	}
 
 	cr := res.ContainerRegistries[0]
-	data.updateState(ctx, d.client, cr, true, &resp.Diagnostics)
+	data.updateState(cr)
+	data.User = flattenContainerRegistryUsersDataSource(getContainerRegistryUsers(ctx, d.client, cr))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func flattenContainerRegistryUsersDataSource(users []*iaas.ContainerRegistryUser) []*containerRegistryUserDSModel {
+	var results []*containerRegistryUserDSModel
+	for _, user := range users {
+		v := &containerRegistryUserDSModel{
+			Name:       types.StringValue(user.UserName),
+			Password:   types.StringValue(""),
+			Permission: types.StringValue(string(user.Permission)),
+		}
+		results = append(results, v)
+	}
+	return results
 }

--- a/internal/service/container_registry/data_source_test.go
+++ b/internal/service/container_registry/data_source_test.go
@@ -29,10 +29,12 @@ func TestAccSakuraDataSourceContainerRegistry_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
 					resource.TestCheckResourceAttr(resourceName, "access_level", "none"),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "2"),
+					/* 現状userのレスポンスはユーザが登録された順とは確定していないため、順番に依存するテストは一旦コメントアウト
 					resource.TestCheckResourceAttr(resourceName, "user.0.name", "user1"),
 					resource.TestCheckResourceAttr(resourceName, "user.0.permission", "readwrite"),
 					resource.TestCheckResourceAttr(resourceName, "user.1.name", "user2"),
 					resource.TestCheckResourceAttr(resourceName, "user.1.permission", "readonly"),
+					*/
 				),
 			},
 		},
@@ -49,12 +51,12 @@ resource "sakura_container_registry" "foobar" {
   tags        = ["tag1", "tag2"]
 
   user = [{
-    name       = "user1"
+    name       = "user2"
     password   = "{{ .arg2 }}"
     permission = "readwrite"
   },
   {
-    name     = "user2"
+    name     = "user1"
     password = "{{ .arg2 }}"
     permission = "readonly"
   }]

--- a/internal/service/container_registry/model.go
+++ b/internal/service/container_registry/model.go
@@ -6,7 +6,6 @@ package container_registry
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/sacloud/iaas-api-go"
 	iaastypes "github.com/sacloud/iaas-api-go/types"
@@ -16,33 +15,19 @@ import (
 
 type containerRegistryBaseModel struct {
 	common.SakuraBaseModel
-	AccessLevel    types.String                  `tfsdk:"access_level"`
-	VirtualDomain  types.String                  `tfsdk:"virtual_domain"`
-	SubDomainLabel types.String                  `tfsdk:"subdomain_label"`
-	FQDN           types.String                  `tfsdk:"fqdn"`
-	IconID         types.String                  `tfsdk:"icon_id"`
-	User           []*containerRegistryUserModel `tfsdk:"user"`
+	AccessLevel    types.String `tfsdk:"access_level"`
+	VirtualDomain  types.String `tfsdk:"virtual_domain"`
+	SubDomainLabel types.String `tfsdk:"subdomain_label"`
+	FQDN           types.String `tfsdk:"fqdn"`
+	IconID         types.String `tfsdk:"icon_id"`
 }
 
-type containerRegistryUserModel struct {
-	Name       types.String `tfsdk:"name"`
-	Password   types.String `tfsdk:"password"`
-	Permission types.String `tfsdk:"permission"`
-}
-
-func (model *containerRegistryBaseModel) updateState(ctx context.Context, c *common.APIClient, reg *iaas.ContainerRegistry, includePassword bool, diags *diag.Diagnostics) {
-	users := getContainerRegistryUsers(ctx, c, reg)
-	if users == nil {
-		diags.AddError("API Read Error", "failed to get users for Container Registry")
-		return
-	}
-
+func (model *containerRegistryBaseModel) updateState(reg *iaas.ContainerRegistry) {
 	model.UpdateBaseState(reg.ID.String(), reg.Name, reg.Description, reg.Tags)
 	model.AccessLevel = types.StringValue(string(reg.AccessLevel))
 	model.VirtualDomain = types.StringValue(reg.VirtualDomain)
 	model.SubDomainLabel = types.StringValue(reg.SubDomainLabel)
 	model.FQDN = types.StringValue(reg.FQDN)
-	model.User = flattenContainerRegistryUsers(model.User, users, includePassword)
 	if reg.IconID.IsEmpty() {
 		model.IconID = types.StringNull()
 	} else {
@@ -59,42 +44,22 @@ func getContainerRegistryUsers(ctx context.Context, client *common.APIClient, us
 	return users.Users
 }
 
-func expandContainerRegistryUsers(users []*containerRegistryUserModel) []*registryBuilder.User {
+func expandContainerRegistryUsers(users, configUsers []*containerRegistryUserModel) []*registryBuilder.User {
 	if len(users) == 0 {
 		return nil
 	}
 
 	var results []*registryBuilder.User
-	for _, u := range users {
+	for i, u := range users {
+		password := u.Password.ValueString()
+		if password == "" {
+			password = configUsers[i].PasswordWO.ValueString()
+		}
 		results = append(results, &registryBuilder.User{
 			UserName:   u.Name.ValueString(),
-			Password:   u.Password.ValueString(),
+			Password:   password,
 			Permission: iaastypes.EContainerRegistryPermission(u.Permission.ValueString()),
 		})
-	}
-	return results
-}
-
-func flattenContainerRegistryUsers(conf []*containerRegistryUserModel, users []*iaas.ContainerRegistryUser, includePassword bool) []*containerRegistryUserModel {
-	inputs := expandContainerRegistryUsers(conf)
-
-	var results []*containerRegistryUserModel
-	for _, user := range users {
-		v := &containerRegistryUserModel{
-			Name:       types.StringValue(user.UserName),
-			Permission: types.StringValue(string(user.Permission)),
-		}
-		if includePassword {
-			password := ""
-			for _, i := range inputs {
-				if i.UserName == user.UserName {
-					password = i.Password
-					break
-				}
-			}
-			v.Password = types.StringValue(password)
-		}
-		results = append(results, v)
 	}
 	return results
 }

--- a/internal/service/container_registry/resource.go
+++ b/internal/service/container_registry/resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -17,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/sacloud/iaas-api-go"
 	iaastypes "github.com/sacloud/iaas-api-go/types"
 	registryBuilder "github.com/sacloud/iaas-service-go/containerregistry/builder"
@@ -52,7 +54,16 @@ func (r *containerRegistryResource) Configure(ctx context.Context, req resource.
 
 type containerRegistryResourceModel struct {
 	containerRegistryBaseModel
-	Timeouts timeouts.Value `tfsdk:"timeouts"`
+	User     []*containerRegistryUserModel `tfsdk:"user"`
+	Timeouts timeouts.Value                `tfsdk:"timeouts"`
+}
+
+type containerRegistryUserModel struct {
+	Name              types.String `tfsdk:"name"`
+	Password          types.String `tfsdk:"password"`
+	PasswordWO        types.String `tfsdk:"password_wo"`
+	PasswordWOVersion types.Int32  `tfsdk:"password_wo_version"`
+	Permission        types.String `tfsdk:"permission"`
 }
 
 func (r *containerRegistryResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -95,7 +106,8 @@ func (r *containerRegistryResource) Schema(ctx context.Context, req resource.Sch
 				Computed:    true,
 				Description: "The FQDN for accessing the Container Registry. FQDN is built from `subdomain_label` + `.sakuracr.jp`",
 			},
-			"user": schema.SetNestedAttribute{
+			// Setではwrite-onlyが使えないため、Listにする。CR API経由でのユーザ取得は順序が不定なため、レスポンスはチェックせず、configの値をそのまま使う。
+			"user": schema.ListNestedAttribute{
 				Optional:    true,
 				Description: "User accounts for accessing the Container Registry",
 				NestedObject: schema.NestedAttributeObject{
@@ -105,9 +117,30 @@ func (r *containerRegistryResource) Schema(ctx context.Context, req resource.Sch
 							Description: "The user name used to authenticate remote access",
 						},
 						"password": schema.StringAttribute{
-							Required:    true,
+							Optional:    true,
 							Sensitive:   true,
 							Description: "The password used to authenticate remote access",
+							Validators: []validator.String{
+								stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("user").AtAnyListIndex().AtName("password_wo")),
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("password_wo")),
+							},
+						},
+						"password_wo": schema.StringAttribute{
+							Optional:    true,
+							WriteOnly:   true,
+							Description: "The password used to authenticate remote access",
+							Validators: []validator.String{
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("password")),
+								stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("password_wo_version")),
+							},
+						},
+						"password_wo_version": schema.Int32Attribute{
+							Optional:    true,
+							Description: "The version of the password_wo field. This value must be greater than 0 when set. Increment this when changing password.",
+							Validators: []validator.Int32{
+								int32validator.AtLeast(1),
+								int32validator.AlsoRequires(path.MatchRelative().AtParent().AtName("password_wo")),
+							},
 						},
 						"permission": schema.StringAttribute{
 							Required: true,
@@ -135,8 +168,9 @@ func (r *containerRegistryResource) ImportState(ctx context.Context, req resourc
 }
 
 func (r *containerRegistryResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan containerRegistryResourceModel
+	var plan, config containerRegistryResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -144,7 +178,7 @@ func (r *containerRegistryResource) Create(ctx context.Context, req resource.Cre
 	ctx, cancel := common.SetupTimeoutCreate(ctx, plan.Timeouts, common.Timeout5min)
 	defer cancel()
 
-	builder := expandContainerRegistryBuilder(&plan, r.client, "")
+	builder := expandContainerRegistryBuilder(&plan, &config, r.client, "")
 	reg, err := builder.Build(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to create SakuraCloud Container Registry: %s", err))
@@ -156,7 +190,7 @@ func (r *containerRegistryResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	plan.updateState(ctx, r.client, gotReg, true, &resp.Diagnostics)
+	plan.updateState(gotReg)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -171,14 +205,24 @@ func (r *containerRegistryResource) Read(ctx context.Context, req resource.ReadR
 	if reg == nil {
 		return
 	}
-	state.updateState(ctx, r.client, reg, true, &resp.Diagnostics)
-
+	state.updateState(reg)
+	if len(state.User) == 0 {
+		users := getContainerRegistryUsers(ctx, r.client, reg)
+		if users == nil {
+			resp.Diagnostics.AddError("Read: API Error", "failed to get users for Container Registry")
+			return
+		}
+		if len(users) > 0 {
+			state.User = flattenContainerRegistryUsers(users)
+		}
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
 func (r *containerRegistryResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan containerRegistryResourceModel
+	var plan, config containerRegistryResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -192,7 +236,7 @@ func (r *containerRegistryResource) Update(ctx context.Context, req resource.Upd
 		resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to read SakuraCloud Container Registry[%s]: %s", plan.ID.ValueString(), err))
 		return
 	}
-	builder := expandContainerRegistryBuilder(&plan, r.client, reg.SettingsHash)
+	builder := expandContainerRegistryBuilder(&plan, &config, r.client, reg.SettingsHash)
 	builder.ID = reg.ID
 	if _, err := builder.Build(ctx); err != nil {
 		resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to update SakuraCloud Container Registry[%s]: %s", plan.ID.ValueString(), err))
@@ -203,8 +247,7 @@ func (r *containerRegistryResource) Update(ctx context.Context, req resource.Upd
 	if gotReg == nil {
 		return
 	}
-
-	plan.updateState(ctx, r.client, gotReg, true, &resp.Diagnostics)
+	plan.updateState(gotReg)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -230,7 +273,7 @@ func (r *containerRegistryResource) Delete(ctx context.Context, req resource.Del
 	}
 }
 
-func expandContainerRegistryBuilder(d *containerRegistryResourceModel, c *common.APIClient, settingsHash string) *registryBuilder.Builder {
+func expandContainerRegistryBuilder(d, config *containerRegistryResourceModel, c *common.APIClient, settingsHash string) *registryBuilder.Builder {
 	return &registryBuilder.Builder{
 		Name:           d.Name.ValueString(),
 		Description:    d.Description.ValueString(),
@@ -239,7 +282,7 @@ func expandContainerRegistryBuilder(d *containerRegistryResourceModel, c *common
 		AccessLevel:    iaastypes.EContainerRegistryAccessLevel(d.AccessLevel.ValueString()),
 		VirtualDomain:  d.VirtualDomain.ValueString(),
 		SubDomainLabel: d.SubDomainLabel.ValueString(),
-		Users:          expandContainerRegistryUsers(d.User),
+		Users:          expandContainerRegistryUsers(d.User, config.User),
 		SettingsHash:   settingsHash,
 		Client:         iaas.NewContainerRegistryOp(c),
 	}
@@ -258,4 +301,19 @@ func getContainerRegistry(ctx context.Context, client *common.APIClient, id iaas
 	}
 
 	return reg
+}
+
+func flattenContainerRegistryUsers(users []*iaas.ContainerRegistryUser) []*containerRegistryUserModel {
+	var results []*containerRegistryUserModel
+	for _, user := range users {
+		v := &containerRegistryUserModel{
+			Name:              types.StringValue(user.UserName),
+			Password:          types.StringNull(),
+			PasswordWO:        types.StringNull(),
+			PasswordWOVersion: types.Int32Null(),
+			Permission:        types.StringValue(string(user.Permission)),
+		}
+		results = append(results, v)
+	}
+	return results
 }

--- a/internal/service/container_registry/resource_test.go
+++ b/internal/service/container_registry/resource_test.go
@@ -82,6 +82,72 @@ func TestAccSakuraContainerRegistry_basic(t *testing.T) {
 	})
 }
 
+func TestAccSakuraContainerRegistry_WObasic(t *testing.T) {
+	resourceName := "sakura_container_registry.foobar"
+	rand := test.RandomName()
+	subDomainLabel := acctest.RandStringFromCharSet(60, acctest.CharSetAlpha)
+	password := test.RandomPassword()
+
+	var reg iaas.ContainerRegistry
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckSakuraContainerRegistryDestroy,
+			test.CheckSakuraIconDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraContainerRegistry_basicWO, rand, subDomainLabel, password),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraContainerRegistryExists(resourceName, &reg),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
+					resource.TestCheckResourceAttr(resourceName, "virtual_domain", subDomainLabel+".usacloud.jp"),
+					resource.TestCheckResourceAttr(resourceName, "fqdn", subDomainLabel+".sakuracr.jp"),
+					resource.TestCheckResourceAttr(resourceName, "access_level", "none"),
+					resource.TestCheckResourceAttr(resourceName, "description", "description"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2"),
+					resource.TestCheckResourceAttr(resourceName, "user.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "user.0.name", "user1"),
+					resource.TestCheckNoResourceAttr(resourceName, "user.0.password"),
+					resource.TestCheckNoResourceAttr(resourceName, "user.0.password_wo"),
+					resource.TestCheckResourceAttr(resourceName, "user.0.permission", "readwrite"),
+					resource.TestCheckResourceAttr(resourceName, "user.0.password_wo_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user.1.name", "user2"),
+					resource.TestCheckNoResourceAttr(resourceName, "user.1.password"),
+					resource.TestCheckNoResourceAttr(resourceName, "user.1.password_wo"),
+					resource.TestCheckResourceAttr(resourceName, "user.1.permission", "readonly"),
+					resource.TestCheckResourceAttr(resourceName, "user.1.password_wo_version", "1"),
+				),
+			},
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraContainerRegistry_updateWO, rand, subDomainLabel, password),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraContainerRegistryExists(resourceName, &reg),
+					resource.TestCheckResourceAttr(resourceName, "name", rand+"-upd"),
+					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
+					resource.TestCheckResourceAttr(resourceName, "virtual_domain", subDomainLabel+"-upd.usacloud.jp"),
+					resource.TestCheckResourceAttr(resourceName, "fqdn", subDomainLabel+".sakuracr.jp"),
+					resource.TestCheckResourceAttr(resourceName, "access_level", "none"),
+					resource.TestCheckResourceAttr(resourceName, "description", "description-upd"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1-upd"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2-upd"),
+					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user.0.name", "user1"),
+					resource.TestCheckNoResourceAttr(resourceName, "user.0.password"),
+					resource.TestCheckNoResourceAttr(resourceName, "user.0.password_wo"),
+					resource.TestCheckResourceAttr(resourceName, "user.0.permission", "readonly"),
+					resource.TestCheckResourceAttr(resourceName, "user.0.password_wo_version", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckSakuraContainerRegistryExists(n string, cr *iaas.ContainerRegistry) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -175,6 +241,50 @@ resource "sakura_container_registry" "foobar" {
     name       = "user1"
     password   = "{{ .arg2 }}"
     permission = "all"
+  }]
+}
+`
+
+var testAccSakuraContainerRegistry_basicWO = `
+resource "sakura_container_registry" "foobar" {
+  name            = "{{ .arg0 }}"
+  virtual_domain  = "{{ .arg1 }}.usacloud.jp"
+  subdomain_label = "{{ .arg1 }}"
+  access_level    = "none"
+
+  description = "description"
+  tags        = ["tag1", "tag2"]
+
+  user = [{
+    name        = "user1"
+    permission  = "readwrite"
+    password_wo = "{{ .arg2 }}"
+    password_wo_version = 1
+  },
+  {
+    name        = "user2"
+    permission  = "readonly"
+    password_wo = "{{ .arg2 }}"
+    password_wo_version = 1
+  }]
+}
+`
+
+var testAccSakuraContainerRegistry_updateWO = `
+resource "sakura_container_registry" "foobar" {
+  name            = "{{ .arg0 }}-upd"
+  virtual_domain  = "{{ .arg1 }}-upd.usacloud.jp"
+  subdomain_label = "{{ .arg1 }}"
+  access_level    = "none"
+
+  description = "description-upd"
+  tags        = ["tag1-upd", "tag2-upd"]
+
+  user = [{
+    name        = "user1"
+    permission  = "readonly"
+    password_wo = "{{ .arg2 }}abc"
+    password_wo_version = 2
   }]
 }
 `

--- a/internal/service/enhanced_lb/model.go
+++ b/internal/service/enhanced_lb/model.go
@@ -5,11 +5,14 @@ package enhanced_lb
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/terraform-provider-sakura/internal/common"
+	"github.com/sacloud/terraform-provider-sakura/internal/common/utils"
 )
 
 type enhancedLBBaseModel struct {
@@ -183,7 +186,7 @@ func (model *enhancedLBBaseModel) updateState(ctx context.Context, client *commo
 	model.Server = flattenEnhancedLBServers(data)
 	model.Rule = flattenEnhancedLBRules(data)
 	model.LetsEncrypt = flattenEnhancedLBACMESetting(data)
-	model.Certificate = flattenEnhancedLBCerts(certs)
+	model.Certificate = flattenEnhancedLBCerts(certs, model.Certificate)
 	model.MonitoringSuite = common.FlattenMonitoringSuiteLog(data.MonitoringSuiteLog)
 	model.OriginGuard = flattenEnhancedLBOriginGuard(data)
 	model.StrictRule = flattenEnhancedLBStrictRule(data)
@@ -289,27 +292,52 @@ func flattenEnhancedLBRules(elb *iaas.ProxyLB) []enhancedLBRuleModel {
 	return results
 }
 
-func flattenEnhancedLBCerts(certs *iaas.ProxyLBCertificates) types.Object {
+func flattenEnhancedLBCerts(certs *iaas.ProxyLBCertificates, modelObj types.Object) types.Object {
 	v := types.ObjectNull(enhancedLBCertificateModel{}.AttributeTypes())
 	if certs == nil {
 		return v
+	}
+
+	// null/unknownの場合はAsで変換できないので事前にチェックし、それらの場合はnilとしてPrivateKeyとかは設定しないようにする
+	model := &enhancedLBCertificateModel{}
+	if utils.IsKnown(modelObj) {
+		diags := modelObj.As(context.Background(), model, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			model = nil
+		}
+	} else {
+		model = nil
 	}
 
 	elbCert := enhancedLBCertificateModel{}
 	if certs.PrimaryCert != nil {
 		elbCert.ServerCert = types.StringValue(certs.PrimaryCert.ServerCertificate)
 		elbCert.IntermediateCert = types.StringValue(certs.PrimaryCert.IntermediateCertificate)
-		elbCert.PrivateKey = types.StringValue(certs.PrimaryCert.PrivateKey)
+		if model != nil {
+			elbCert.PrivateKey = types.StringValue(model.PrivateKey.ValueString()) // 秘密鍵はAPIレスポンスに含まれなくなるため、既存の状態から引き継ぐ
+		} else {
+			elbCert.PrivateKey = types.StringValue("")
+		}
 		elbCert.CommonName = types.StringValue(certs.PrimaryCert.CertificateCommonName)
 		elbCert.SubjectAltNames = types.StringValue(certs.PrimaryCert.CertificateAltNames)
 	}
 	if len(certs.AdditionalCerts) > 0 {
 		var additionalCerts []enhancedLBAdditionalCertificateModel
 		for _, ac := range certs.AdditionalCerts {
+			pKey := types.StringValue("")
+			if model != nil {
+				for _, c := range model.AdditionalCertificate {
+					if strings.TrimSpace(c.ServerCert.ValueString()) == strings.TrimSpace(ac.ServerCertificate) &&
+						strings.TrimSpace(c.IntermediateCert.ValueString()) == strings.TrimSpace(ac.IntermediateCertificate) {
+						pKey = types.StringValue(c.PrivateKey.ValueString())
+						break
+					}
+				}
+			}
 			additionalCerts = append(additionalCerts, enhancedLBAdditionalCertificateModel{
 				ServerCert:       types.StringValue(ac.ServerCertificate),
 				IntermediateCert: types.StringValue(ac.IntermediateCertificate),
-				PrivateKey:       types.StringValue(ac.PrivateKey),
+				PrivateKey:       pKey,
 			})
 		}
 		elbCert.AdditionalCertificate = additionalCerts

--- a/internal/service/enhanced_lb/resource.go
+++ b/internal/service/enhanced_lb/resource.go
@@ -293,6 +293,7 @@ func (r *enhancedLBResource) Schema(ctx context.Context, _ resource.SchemaReques
 					},
 				},
 			},
+			// WriteOnlyにしたいがするとComputedを外す必要があり、互換性問題が起きる可能性が高いので現状はSensitiveのみを維持
 			"certificate": schema.SingleNestedAttribute{
 				Optional: true,
 				Computed: true,

--- a/internal/service/enhanced_lb/resource_acme.go
+++ b/internal/service/enhanced_lb/resource_acme.go
@@ -326,7 +326,7 @@ func (model *enhancedLBACMEResourceModel) updateState(ctx context.Context, clien
 	}
 
 	model.ID = types.StringValue(data.ID.String())
-	model.Certificate = flattenEnhancedLBCerts(certs)
+	model.Certificate = flattenEnhancedLBCerts(certs, model.Certificate)
 
 	return nil
 }

--- a/internal/service/kms/resource.go
+++ b/internal/service/kms/resource.go
@@ -56,6 +56,7 @@ func (r *kmsResource) Configure(ctx context.Context, req resource.ConfigureReque
 type kmsResourceModel struct {
 	kmsBaseModel
 	PlainKey                types.String   `tfsdk:"plain_key"`
+	PlainKeyWO              types.String   `tfsdk:"plain_key_wo"`
 	ScheduleDestructionDays types.Int32    `tfsdk:"schedule_destruction_days"`
 	RotateVersion           types.Int64    `tfsdk:"rotate_version"`
 	Timeouts                timeouts.Value `tfsdk:"timeouts"`
@@ -90,6 +91,18 @@ func (r *kmsResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp
 				Optional:    true,
 				Sensitive:   true,
 				Description: "Plain key for imported KMS key. Required when `key_origin` is 'imported'.",
+				Validators: []validator.String{
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("plain_key_wo")),
+					stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("plain_key_wo")),
+				},
+			},
+			"plain_key_wo": schema.StringAttribute{
+				Optional:    true,
+				WriteOnly:   true,
+				Description: "Plain key for imported KMS key. Required when `key_origin` is 'imported'.",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("plain_key")),
+				},
 			},
 			"schedule_destruction_days": schema.Int32Attribute{
 				Optional:    true,
@@ -129,8 +142,9 @@ func (r *kmsResource) ImportState(ctx context.Context, req resource.ImportStateR
 }
 
 func (r *kmsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan kmsResourceModel
+	var plan, config kmsResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -138,7 +152,7 @@ func (r *kmsResource) Create(ctx context.Context, req resource.CreateRequest, re
 	ctx, cancel := common.SetupTimeoutCreate(ctx, plan.Timeouts, common.Timeout5min)
 	defer cancel()
 
-	keyReq, err := expandKMSCreateKey(&plan)
+	keyReq, err := expandKMSCreateKey(&plan, &config)
 	if err != nil {
 		resp.Diagnostics.AddError("Create: Expand Error", fmt.Sprintf("failed to expand create key request: %s", err))
 		return
@@ -265,7 +279,7 @@ func getKMS(ctx context.Context, client *v1.Client, id string, state *tfsdk.Stat
 	return key
 }
 
-func expandKMSCreateKey(model *kmsResourceModel) (v1.CreateKey, error) {
+func expandKMSCreateKey(model, config *kmsResourceModel) (v1.CreateKey, error) {
 	keyOrig := model.KeyOrigin.ValueString()
 	var req v1.CreateKey
 	if keyOrig == "generated" {
@@ -275,6 +289,9 @@ func expandKMSCreateKey(model *kmsResourceModel) (v1.CreateKey, error) {
 		}
 	} else {
 		plainKey := model.PlainKey.ValueString()
+		if config != nil && config.PlainKeyWO.ValueString() != "" {
+			plainKey = config.PlainKeyWO.ValueString()
+		}
 		if plainKey == "" {
 			return v1.CreateKey{}, errors.New("plain_key is required when key_origin is 'imported'")
 		}

--- a/internal/service/kms/resource_test.go
+++ b/internal/service/kms/resource_test.go
@@ -97,6 +97,35 @@ func TestAccSakuraResourceKMS_imported(t *testing.T) {
 	})
 }
 
+func TestAccSakuraResourceKMS_importedWithWO(t *testing.T) {
+	resourceName := "sakura_kms.foobar"
+	rand := test.RandomName()
+
+	var key v1.Key
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraKMSDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraKMS_importedWithWO, rand),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraKMSExists(resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "description", "description with plain key"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "tag2"),
+					resource.TestCheckResourceAttr(resourceName, "key_origin", "imported"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckNoResourceAttr(resourceName, "plain_key_wo"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckSakuraKMSDestroy(s *terraform.State) error {
 	client := test.AccClientGetter()
 	keyOp := kms.NewKeyOp(client.KmsClient)
@@ -177,4 +206,13 @@ resource "sakura_kms" "foobar2" {
   tags        = ["tag1"]
   key_origin  = "imported"
   rotate_version = 1
+}`
+
+var testAccSakuraKMS_importedWithWO = `
+resource "sakura_kms" "foobar" {
+  name         = "{{ .arg0 }}"
+  description  = "description with plain key"
+  tags         = ["tag1", "tag2"]
+  key_origin   = "imported"
+  plain_key_wo = "AfL5zzjD4RgeFQm3vvAADwPNrurNUc616877wsa8v4w="
 }`

--- a/internal/service/local_router/model.go
+++ b/internal/service/local_router/model.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sacloud/iaas-api-go"
 	iaastypes "github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/terraform-provider-sakura/internal/common"
+	"github.com/sacloud/terraform-provider-sakura/internal/common/utils"
 )
 
 type localRouterBaseModel struct {
@@ -34,10 +35,12 @@ type localRouterNetworkInterfaceModel struct {
 }
 
 type localRouterPeerModel struct {
-	PeerID      types.String `tfsdk:"peer_id"`
-	SecretKey   types.String `tfsdk:"secret_key"`
-	Enabled     types.Bool   `tfsdk:"enabled"`
-	Description types.String `tfsdk:"description"`
+	PeerID             types.String `tfsdk:"peer_id"`
+	SecretKey          types.String `tfsdk:"secret_key"`
+	SecretKeyWO        types.String `tfsdk:"secret_key_wo"`
+	SecretKeyWOVersion types.Int32  `tfsdk:"secret_key_wo_version"`
+	Enabled            types.Bool   `tfsdk:"enabled"`
+	Description        types.String `tfsdk:"description"`
 }
 
 type localRouterStaticRouteModel struct {
@@ -73,11 +76,24 @@ func (model *localRouterBaseModel) updateState(lr *iaas.LocalRouter) {
 	if len(lr.Peers) > 0 {
 		var peers []localRouterPeerModel
 		for _, p := range lr.Peers {
+			key := types.StringNull()
+			version := types.Int32Null()
+			for _, v := range model.Peer {
+				if v.PeerID.ValueString() == p.ID.String() {
+					if utils.IsKnown(v.SecretKeyWOVersion) {
+						version = types.Int32Value(v.SecretKeyWOVersion.ValueInt32())
+					} else {
+						key = types.StringValue(v.SecretKey.ValueString())
+					}
+					break
+				}
+			}
 			peers = append(peers, localRouterPeerModel{
-				PeerID:      types.StringValue(p.ID.String()),
-				SecretKey:   types.StringValue(p.SecretKey),
-				Enabled:     types.BoolValue(p.Enabled),
-				Description: types.StringValue(p.Description),
+				PeerID:             types.StringValue(p.ID.String()),
+				SecretKey:          key,
+				SecretKeyWOVersion: version,
+				Enabled:            types.BoolValue(p.Enabled),
+				Description:        types.StringValue(p.Description),
 			})
 		}
 		model.Peer = peers
@@ -94,5 +110,6 @@ func (model *localRouterBaseModel) updateState(lr *iaas.LocalRouter) {
 		model.StaticRoute = routes
 	}
 
+	// 将来的には空が返るようになるが、現状このフィールドに依存しているユーザがいる可能性があるため、レスポンスを利用する
 	model.SecretKeys = common.StringsToTlist(lr.SecretKeys)
 }

--- a/internal/service/local_router/resource.go
+++ b/internal/service/local_router/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -132,9 +133,30 @@ func (r *localRouterResource) Schema(ctx context.Context, req resource.SchemaReq
 							},
 						},
 						"secret_key": schema.StringAttribute{
-							Required:    true,
+							Optional:    true,
 							Sensitive:   true,
 							Description: "The secret key of the peer LocalRouter",
+							Validators: []validator.String{
+								stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("peer").AtAnyListIndex().AtName("secret_key_wo")),
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("secret_key_wo")),
+							},
+						},
+						"secret_key_wo": schema.StringAttribute{
+							Optional:    true,
+							WriteOnly:   true,
+							Description: "The secret key of the peer LocalRouter",
+							Validators: []validator.String{
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("secret_key")),
+								stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("secret_key_wo_version")),
+							},
+						},
+						"secret_key_wo_version": schema.Int32Attribute{
+							Optional:    true,
+							Description: "The version of the secret_key_wo field. This value must be greater than 0 when set. Increment this when changing secret_key_wo.",
+							Validators: []validator.Int32{
+								int32validator.AtLeast(1),
+								int32validator.AlsoRequires(path.MatchRelative().AtParent().AtName("secret_key_wo")),
+							},
 						},
 						"enabled": schema.BoolAttribute{
 							Optional:    true,
@@ -183,8 +205,9 @@ func (r *localRouterResource) ImportState(ctx context.Context, req resource.Impo
 }
 
 func (r *localRouterResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan localRouterResourceModel
+	var plan, config localRouterResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -192,7 +215,7 @@ func (r *localRouterResource) Create(ctx context.Context, req resource.CreateReq
 	ctx, cancel := common.SetupTimeoutCreate(ctx, plan.Timeouts, common.Timeout20min)
 	defer cancel()
 
-	builder := expandLocalRouterBuilder(&plan, r.client)
+	builder := expandLocalRouterBuilder(&plan, &config, r.client)
 	if err := builder.Validate(ctx); err != nil {
 		resp.Diagnostics.AddError("Create: Validation Error", fmt.Sprintf("failed to validate parameter for LocalRouter: %s", err))
 		return
@@ -224,8 +247,9 @@ func (r *localRouterResource) Read(ctx context.Context, req resource.ReadRequest
 }
 
 func (r *localRouterResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan localRouterResourceModel
+	var plan, config localRouterResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -237,7 +261,7 @@ func (r *localRouterResource) Update(ctx context.Context, req resource.UpdateReq
 	common.SakuraMutexKV.Lock(id)
 	defer common.SakuraMutexKV.Unlock(id)
 
-	builder := expandLocalRouterBuilder(&plan, r.client)
+	builder := expandLocalRouterBuilder(&plan, &config, r.client)
 	if err := builder.Validate(ctx); err != nil {
 		resp.Diagnostics.AddError("Update: Validation Error", fmt.Sprintf("failed to validate parameter for LocalRouter[%s]: %s", id, err))
 		return
@@ -296,13 +320,26 @@ func getLocalRouter(ctx context.Context, client *common.APIClient, id string, st
 	return lr
 }
 
-func expandLocalRouterBuilder(model *localRouterResourceModel, client *common.APIClient) *localrouter.Builder {
+func expandLocalRouterBuilder(model, config *localRouterResourceModel, client *common.APIClient) *localrouter.Builder {
 	b := &localrouter.Builder{
 		Name:        model.Name.ValueString(),
 		Description: model.Description.ValueString(),
 		Tags:        common.TsetToStrings(model.Tags),
 		IconID:      common.ExpandSakuraCloudID(model.IconID),
 		Client:      localrouter.NewAPIClient(client),
+	}
+
+	secretKeys := map[string]string{}
+	for i, p := range model.Peer {
+		peerID := p.PeerID.ValueString()
+		if peerID == "" {
+			continue
+		}
+		key := p.SecretKey.ValueString()
+		if config != nil && config.Peer[i].SecretKeyWO.ValueString() != "" {
+			key = config.Peer[i].SecretKeyWO.ValueString()
+		}
+		secretKeys[peerID] = key
 	}
 
 	if model.Switch != nil {
@@ -324,9 +361,13 @@ func expandLocalRouterBuilder(model *localRouterResourceModel, client *common.AP
 
 	if len(model.Peer) > 0 {
 		for _, p := range model.Peer {
+			secretKey := p.SecretKey.ValueString()
+			if v, ok := secretKeys[p.PeerID.ValueString()]; ok {
+				secretKey = v
+			}
 			b.Peers = append(b.Peers, &iaas.LocalRouterPeer{
 				ID:          common.ExpandSakuraCloudID(p.PeerID),
-				SecretKey:   p.SecretKey.ValueString(),
+				SecretKey:   secretKey,
 				Enabled:     p.Enabled.ValueBool(),
 				Description: p.Description.ValueString(),
 			})

--- a/internal/service/local_router/resource_test.go
+++ b/internal/service/local_router/resource_test.go
@@ -274,8 +274,11 @@ func TestAccSakuraLocalRouter_peering(t *testing.T) {
 		t.Skip("This test only run if SAKURA_RESOURCE_REQUIRED_TEST environment variable is set")
 	}
 
-	resourceName1 := "sakura_local_router.foobar1"
-	resourceName2 := "sakura_local_router.foobar2"
+	test.SkipIfEnvIsNotSet(t, "SAKURA_LOCAL_ROUTER_PEER_ID", "SAKURA_LOCAL_ROUTER_SECRET_KEY")
+
+	resourceName := "sakura_local_router.foobar"
+	peerID := os.Getenv("SAKURA_LOCAL_ROUTER_PEER_ID")
+	secretKey := os.Getenv("SAKURA_LOCAL_ROUTER_SECRET_KEY")
 	rand := test.RandomName()
 
 	resource.Test(t, resource.TestCase{
@@ -288,18 +291,49 @@ func TestAccSakuraLocalRouter_peering(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraLocalRouter_peering, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraLocalRouter_peering, rand, peerID, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(resourceName1, "id", resourceName2, "peer.0.peer_id"),
-					resource.TestCheckResourceAttrPair(resourceName1, "secret_keys.0", resourceName2, "peer.0.secret_key"),
-					resource.TestCheckResourceAttr(resourceName2, "peer.0.description", "description"),
+					resource.TestCheckResourceAttr(resourceName, "peer.0.secret_key", secretKey),
+					resource.TestCheckResourceAttr(resourceName, "peer.0.description", "description"),
 				),
 			},
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraLocalRouter_peeringDisconnect, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraLocalRouter_peeringDisconnect, rand, peerID, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName1, "peer.#", "0"),
-					resource.TestCheckResourceAttr(resourceName2, "peer.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "peer.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSakuraLocalRouter_peeringWithWO(t *testing.T) {
+	if !test.IsResourceRequiredTest() {
+		t.Skip("This test only run if SAKURA_RESOURCE_REQUIRED_TEST environment variable is set")
+	}
+
+	test.SkipIfEnvIsNotSet(t, "SAKURA_LOCAL_ROUTER_PEER_ID", "SAKURA_LOCAL_ROUTER_SECRET_KEY")
+
+	resourceName := "sakura_local_router.foobar"
+	peerID := os.Getenv("SAKURA_LOCAL_ROUTER_PEER_ID")
+	secretKey := os.Getenv("SAKURA_LOCAL_ROUTER_SECRET_KEY")
+	rand := test.RandomName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			test.CheckSakuraIconDestroy,
+			testCheckSakuraLocalRouterDestroy,
+			test.CheckSakuravSwitchDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraLocalRouter_peeringWithWO, rand, peerID, secretKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "peer.0.description", "description"),
+					resource.TestCheckResourceAttr(resourceName, "peer.0.secret_key_wo_version", "1"),
+					resource.TestCheckNoResourceAttr(resourceName, "peer.0.secret_key_wo"),
 				),
 			},
 		},
@@ -307,34 +341,15 @@ func TestAccSakuraLocalRouter_peering(t *testing.T) {
 }
 
 const testAccSakuraLocalRouter_peering = `
-resource "sakura_vswitch" "foobar1" {
-  name = "{{ .arg0 }}"
-}
-resource "sakura_vswitch" "foobar2" {
+resource "sakura_vswitch" "foobar" {
   name = "{{ .arg0 }}"
 }
 
 data "sakura_zone" "current" {}
 
-resource "sakura_local_router" "foobar1" {
+resource "sakura_local_router" "foobar" {
   switch = {
-    code     = sakura_vswitch.foobar1.id
-    category = "cloud"
-    zone     = data.sakura_zone.current.name
-  }
-  network_interface = {
-    vip          = "192.168.11.1"
-    ip_addresses = ["192.168.11.11", "192.168.11.12"]
-    netmask      = 24
-    vrid         = 1
-  }
-
-  name        = "{{ .arg0 }}"
-}
-
-resource "sakura_local_router" "foobar2" {
-  switch = {
-    code     = sakura_vswitch.foobar2.id
+    code     = sakura_vswitch.foobar.id
     category = "cloud"
     zone     = data.sakura_zone.current.name
   }
@@ -345,44 +360,25 @@ resource "sakura_local_router" "foobar2" {
     vrid         = 1
   }
   peer = [{
-    peer_id     = sakura_local_router.foobar1.id
-    secret_key  = sakura_local_router.foobar1.secret_keys.0
+    peer_id     = "{{ .arg1 }}"
+    secret_key  = "{{ .arg2 }}"
     description = "description"
   }]
 
-  name        = "{{ .arg0 }}"
+  name = "{{ .arg0 }}"
 }
 `
 
 const testAccSakuraLocalRouter_peeringDisconnect = `
-resource "sakura_vswitch" "foobar1" {
-  name = "{{ .arg0 }}"
-}
-resource "sakura_vswitch" "foobar2" {
+resource "sakura_vswitch" "foobar" {
   name = "{{ .arg0 }}"
 }
 
 data "sakura_zone" "current" {}
 
-resource "sakura_local_router" "foobar1" {
+resource "sakura_local_router" "foobar" {
   switch = {
-    code     = sakura_vswitch.foobar1.id
-    category = "cloud"
-    zone     = data.sakura_zone.current.name
-  }
-  network_interface = {
-    vip          = "192.168.11.1"
-    ip_addresses = ["192.168.11.11", "192.168.11.12"]
-    netmask      = 24
-    vrid         = 1
-  }
-
-  name        = "{{ .arg0 }}"
-}
-
-resource "sakura_local_router" "foobar2" {
-  switch = {
-    code     = sakura_vswitch.foobar2.id
+    code     = sakura_vswitch.foobar.id
     category = "cloud"
     zone     = data.sakura_zone.current.name
   }
@@ -393,6 +389,36 @@ resource "sakura_local_router" "foobar2" {
     vrid         = 1
   }
 
-  name        = "{{ .arg0 }}"
+  name = "{{ .arg0 }}"
+}
+`
+
+const testAccSakuraLocalRouter_peeringWithWO = `
+resource "sakura_vswitch" "foobar" {
+  name = "{{ .arg0 }}"
+}
+
+data "sakura_zone" "current" {}
+
+resource "sakura_local_router" "foobar" {
+  switch = {
+    code     = sakura_vswitch.foobar.id
+    category = "cloud"
+    zone     = data.sakura_zone.current.name
+  }
+  network_interface = {
+    vip          = "192.168.13.1"
+    ip_addresses = ["192.168.13.11", "192.168.13.12"]
+    netmask      = 24
+    vrid         = 1
+  }
+  peer = [{
+    peer_id       = "{{ .arg1 }}"
+    secret_key_wo = "{{ .arg2 }}"
+	secret_key_wo_version = 1
+    description = "description"
+  }]
+
+  name = "{{ .arg0 }}"
 }
 `

--- a/internal/service/simple_monitor/data_source_test.go
+++ b/internal/service/simple_monitor/data_source_test.go
@@ -36,7 +36,7 @@ func TestAccSakuraDataSourceSimpleMonitor_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.host_header", "usacloud.jp"),
 					resource.TestCheckResourceAttr(resourceName, "notify_email_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "notify_slack_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "notify_slack_webhook", testAccSlackWebhook),
+					resource.TestCheckResourceAttr(resourceName, "notify_slack_webhook", ""),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_suite.enabled", "true"),
 				),
 			},

--- a/internal/service/simple_monitor/model.go
+++ b/internal/service/simple_monitor/model.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sacloud/iaas-api-go"
 	iaastypes "github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/terraform-provider-sakura/internal/common"
+	"github.com/sacloud/terraform-provider-sakura/internal/common/utils"
 )
 
 type simpleMonitorBaseModel struct {
@@ -62,7 +63,9 @@ func (m *simpleMonitorBaseModel) updateState(sm *iaas.SimpleMonitor) {
 	m.NotifyEmailEnabled = types.BoolValue(sm.NotifyEmailEnabled.Bool())
 	m.NotifyEmailHTML = types.BoolValue(sm.NotifyEmailHTML.Bool())
 	m.NotifySlackEnabled = types.BoolValue(sm.NotifySlackEnabled.Bool())
-	m.NotifySlackWebhook = types.StringValue(sm.SlackWebhooksURL)
+	if !utils.IsKnown(m.NotifySlackWebhook) {
+		m.NotifySlackWebhook = types.StringValue("")
+	}
 	m.NotifyInterval = types.Int32Value(int32(flattenSimpleMonitorNotifyInterval(sm)))
 	m.MonitoringSuite = common.FlattenMonitoringSuiteLog(sm.MonitoringSuiteLog)
 	if sm.IconID.IsEmpty() {

--- a/internal/service/simple_monitor/resource.go
+++ b/internal/service/simple_monitor/resource.go
@@ -552,12 +552,11 @@ func flattenSimpleMonitorHealthCheckResource(model *simpleMonitorResourceModel, 
 	res := simpleMonitorHealthCheckResourceModel{}
 	res.updateState(sm)
 
-	hc := sm.HealthCheck
 	hcModel := model.HealthCheck
 	switch sm.HealthCheck.Protocol {
 	case iaastypes.SimpleMonitorProtocols.HTTP, iaastypes.SimpleMonitorProtocols.HTTPS:
 		if hcModel.Password.ValueString() != "" {
-			res.Password = types.StringValue(hc.BasicAuthPassword)
+			res.Password = types.StringValue(hcModel.Password.ValueString())
 		} else {
 			res.Password = types.StringNull()
 		}

--- a/internal/service/vpn_router/data_source.go
+++ b/internal/service/vpn_router/data_source.go
@@ -43,7 +43,23 @@ func (d *vpnRouterDataSource) Configure(ctx context.Context, req datasource.Conf
 
 type vpnRouterDataSourceModel struct {
 	vpnRouterBaseModel
-	User []vpnRouterUserDataSourceModel `tfsdk:"user"`
+	L2TP          *vpnRouterL2TPDSModel           `tfsdk:"l2tp"`
+	SiteToSiteVPN []vpnRouterSiteToSiteVPNDSModel `tfsdk:"site_to_site_vpn"`
+	User          []vpnRouterUserDataSourceModel  `tfsdk:"user"`
+}
+
+type vpnRouterL2TPDSModel struct {
+	PreSharedSecret types.String `tfsdk:"pre_shared_secret"`
+	RangeStart      types.String `tfsdk:"range_start"`
+	RangeStop       types.String `tfsdk:"range_stop"`
+}
+
+type vpnRouterSiteToSiteVPNDSModel struct {
+	Peer            types.String `tfsdk:"peer"`
+	RemoteID        types.String `tfsdk:"remote_id"`
+	PreSharedSecret types.String `tfsdk:"pre_shared_secret"`
+	Routes          types.List   `tfsdk:"routes"`
+	LocalPrefix     types.List   `tfsdk:"local_prefix"`
 }
 
 type vpnRouterUserDataSourceModel struct {
@@ -471,7 +487,38 @@ func (d *vpnRouterDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 	data.User = flattenVPNRouterDataSourceUsers(vpnRouter)
+	data.L2TP = flattenVPNRouterDataSourceL2TP(vpnRouter)
+	data.SiteToSiteVPN = flattenVPNRouterDataSourceSiteToSite(vpnRouter)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func flattenVPNRouterDataSourceL2TP(vpcRouter *iaas.VPCRouter) *vpnRouterL2TPDSModel {
+	if vpcRouter.Settings.L2TPIPsecServerEnabled.Bool() {
+		v := vpnRouterL2TPDSModel{
+			PreSharedSecret: types.StringValue(""),
+			RangeStart:      types.StringValue(vpcRouter.Settings.L2TPIPsecServer.RangeStart),
+			RangeStop:       types.StringValue(vpcRouter.Settings.L2TPIPsecServer.RangeStop),
+		}
+		return &v
+	}
+	return nil
+}
+
+func flattenVPNRouterDataSourceSiteToSite(vpcRouter *iaas.VPCRouter) []vpnRouterSiteToSiteVPNDSModel {
+	var s2sSettings []vpnRouterSiteToSiteVPNDSModel
+	if vpcRouter.Settings.SiteToSiteIPsecVPN != nil {
+		for _, s := range vpcRouter.Settings.SiteToSiteIPsecVPN.Config {
+			s2sSettings = append(s2sSettings, vpnRouterSiteToSiteVPNDSModel{
+				Peer:            types.StringValue(s.Peer),
+				RemoteID:        types.StringValue(s.RemoteID),
+				PreSharedSecret: types.StringValue(""),
+				Routes:          common.StringsToTlist(s.Routes),
+				LocalPrefix:     common.StringsToTlist(s.LocalPrefix),
+			})
+		}
+	}
+	return s2sSettings
 }
 
 func flattenVPNRouterDataSourceUsers(vpcRouter *iaas.VPCRouter) []vpnRouterUserDataSourceModel {

--- a/internal/service/vpn_router/model.go
+++ b/internal/service/vpn_router/model.go
@@ -31,11 +31,9 @@ type vpnRouterBaseModel struct {
 	DHCPStaticMapping       []vpnRouterDHCPStaticMappingModel       `tfsdk:"dhcp_static_mapping"`
 	DNSForwarding           types.Object                            `tfsdk:"dns_forwarding"`
 	Firewall                []vpnRouterFirewallModel                `tfsdk:"firewall"`
-	L2TP                    types.Object                            `tfsdk:"l2tp"`
 	PortForwarding          []vpnRouterPortForwardingModel          `tfsdk:"port_forwarding"`
 	PPTP                    types.Object                            `tfsdk:"pptp"`
 	WireGuard               types.Object                            `tfsdk:"wire_guard"`
-	SiteToSiteVPN           []vpnRouterSiteToSiteVPNModel           `tfsdk:"site_to_site_vpn"`
 	SiteToSiteVPNParameter  types.Object                            `tfsdk:"site_to_site_vpn_parameter"`
 	StaticNAT               []vpnRouterStaticNATModel               `tfsdk:"static_nat"`
 	StaticRoute             []vpnRouterStaticRouteModel             `tfsdk:"static_route"`
@@ -110,20 +108,6 @@ type vpnRouterFirewallExprModel struct {
 	Description        types.String `tfsdk:"description"`
 }
 
-type vpnRouterL2TPModel struct {
-	PreSharedSecret types.String `tfsdk:"pre_shared_secret"`
-	RangeStart      types.String `tfsdk:"range_start"`
-	RangeStop       types.String `tfsdk:"range_stop"`
-}
-
-func (m vpnRouterL2TPModel) AttributeTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"pre_shared_secret": types.StringType,
-		"range_start":       types.StringType,
-		"range_stop":        types.StringType,
-	}
-}
-
 type vpnRouterPortForwardingModel struct {
 	Protocol    types.String `tfsdk:"protocol"`
 	PrivateIP   types.String `tfsdk:"private_ip"`
@@ -170,14 +154,6 @@ func (m vpnRouterWireGuardPeerModel) AttributeTypes() map[string]attr.Type {
 		"ip_address": types.StringType,
 		"public_key": types.StringType,
 	}
-}
-
-type vpnRouterSiteToSiteVPNModel struct {
-	Peer            types.String `tfsdk:"peer"`
-	RemoteID        types.String `tfsdk:"remote_id"`
-	PreSharedSecret types.String `tfsdk:"pre_shared_secret"`
-	Routes          types.List   `tfsdk:"routes"`
-	LocalPrefix     types.List   `tfsdk:"local_prefix"`
 }
 
 type vpnRouterSiteToSiteVPNParameterModel struct {
@@ -272,7 +248,7 @@ func (model *vpnRouterBaseModel) updateState(ctx context.Context, client *common
 	model.DHCPStaticMapping = flattenVPNRouterDHCPStaticMappings(vpnRouter)
 	model.DNSForwarding = flattenVPNRouterDNSForwarding(vpnRouter)
 	model.Firewall = flattenVPNRouterFirewalls(vpnRouter)
-	model.L2TP = flattenVPNRouterL2TP(vpnRouter)
+
 	model.PPTP = flattenVPNRouterPPTP(vpnRouter)
 	if vpnRouter.Settings.SyslogHost != "" {
 		model.SyslogHost = types.StringValue(vpnRouter.Settings.SyslogHost)
@@ -296,7 +272,6 @@ func (model *vpnRouterBaseModel) updateState(ctx context.Context, client *common
 	}
 	model.WireGuard = flattenVPNRouterWireGuard(vpnRouter, wireGuardPublicKey)
 	model.PortForwarding = flattenVPNRouterPortForwardings(vpnRouter)
-	model.SiteToSiteVPN = flattenVPNRouterSiteToSiteConfig(vpnRouter)
 	model.SiteToSiteVPNParameter = flattenVPNRouterSiteToSiteParameter(vpnRouter)
 	model.StaticNAT = flattenVPNRouterStaticNAT(vpnRouter)
 	model.StaticRoute = flattenVPNRouterStaticRoutes(vpnRouter)
@@ -520,23 +495,6 @@ func flattenVPNRouterPPTP(vpcRouter *iaas.VPCRouter) types.Object {
 	return v
 }
 
-func flattenVPNRouterL2TP(vpcRouter *iaas.VPCRouter) types.Object {
-	v := types.ObjectNull(vpnRouterL2TPModel{}.AttributeTypes())
-	if vpcRouter.Settings.L2TPIPsecServerEnabled.Bool() {
-		m := vpnRouterL2TPModel{
-			PreSharedSecret: types.StringValue(vpcRouter.Settings.L2TPIPsecServer.PreSharedSecret),
-			RangeStart:      types.StringValue(vpcRouter.Settings.L2TPIPsecServer.RangeStart),
-			RangeStop:       types.StringValue(vpcRouter.Settings.L2TPIPsecServer.RangeStop),
-		}
-		value, diags := types.ObjectValueFrom(context.Background(), m.AttributeTypes(), m)
-		if diags.HasError() {
-			return v
-		}
-		return value
-	}
-	return v
-}
-
 func flattenVPNRouterWireGuard(vpcRouter *iaas.VPCRouter, publicKey string) types.Object {
 	v := types.ObjectNull(vpnRouterWireGuardModel{}.AttributeTypes())
 	if vpcRouter.Settings.WireGuardEnabled.Bool() {
@@ -577,22 +535,6 @@ func flattenVPNRouterPortForwardings(vpcRouter *iaas.VPCRouter) []vpnRouterPortF
 		})
 	}
 	return portForwardings
-}
-
-func flattenVPNRouterSiteToSiteConfig(vpcRouter *iaas.VPCRouter) []vpnRouterSiteToSiteVPNModel {
-	var s2sSettings []vpnRouterSiteToSiteVPNModel
-	if vpcRouter.Settings.SiteToSiteIPsecVPN != nil {
-		for _, s := range vpcRouter.Settings.SiteToSiteIPsecVPN.Config {
-			s2sSettings = append(s2sSettings, vpnRouterSiteToSiteVPNModel{
-				Peer:            types.StringValue(s.Peer),
-				RemoteID:        types.StringValue(s.RemoteID),
-				PreSharedSecret: types.StringValue(s.PreSharedSecret),
-				Routes:          common.StringsToTlist(s.Routes),
-				LocalPrefix:     common.StringsToTlist(s.LocalPrefix),
-			})
-		}
-	}
-	return s2sSettings
 }
 
 func flattenVPNRouterSiteToSiteParameter(vpcRouter *iaas.VPCRouter) types.Object {

--- a/internal/service/vpn_router/resource.go
+++ b/internal/service/vpn_router/resource.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sacloud/iaas-api-go/helper/power"
 	iaastypes "github.com/sacloud/iaas-api-go/types"
 	"github.com/sacloud/terraform-provider-sakura/internal/common"
+	"github.com/sacloud/terraform-provider-sakura/internal/common/utils"
 	"github.com/sacloud/terraform-provider-sakura/internal/desc"
 	sacloudvalidator "github.com/sacloud/terraform-provider-sakura/internal/validator"
 )
@@ -65,8 +66,28 @@ func (d *vpnRouterResource) Configure(ctx context.Context, req resource.Configur
 
 type vpnRouterResourceModel struct {
 	vpnRouterBaseModel
-	User     []vpnRouterUserModel `tfsdk:"user"`
-	Timeouts timeouts.Value       `tfsdk:"timeouts"`
+	L2TP          *vpnRouterL2TPModel           `tfsdk:"l2tp"`
+	SiteToSiteVPN []vpnRouterSiteToSiteVPNModel `tfsdk:"site_to_site_vpn"`
+	User          []vpnRouterUserModel          `tfsdk:"user"`
+	Timeouts      timeouts.Value                `tfsdk:"timeouts"`
+}
+
+type vpnRouterL2TPModel struct {
+	PreSharedSecret          types.String `tfsdk:"pre_shared_secret"`
+	PreSharedSecretWO        types.String `tfsdk:"pre_shared_secret_wo"`
+	PreSharedSecretWOVersion types.Int32  `tfsdk:"pre_shared_secret_wo_version"`
+	RangeStart               types.String `tfsdk:"range_start"`
+	RangeStop                types.String `tfsdk:"range_stop"`
+}
+
+type vpnRouterSiteToSiteVPNModel struct {
+	Peer                     types.String `tfsdk:"peer"`
+	RemoteID                 types.String `tfsdk:"remote_id"`
+	PreSharedSecret          types.String `tfsdk:"pre_shared_secret"`
+	PreSharedSecretWO        types.String `tfsdk:"pre_shared_secret_wo"`
+	PreSharedSecretWOVersion types.Int32  `tfsdk:"pre_shared_secret_wo_version"`
+	Routes                   types.List   `tfsdk:"routes"`
+	LocalPrefix              types.List   `tfsdk:"local_prefix"`
 }
 
 type vpnRouterUserModel struct {
@@ -345,11 +366,31 @@ func (d *vpnRouterResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				Optional: true,
 				Attributes: map[string]schema.Attribute{
 					"pre_shared_secret": schema.StringAttribute{
-						Required:    true,
+						Optional:    true,
 						Sensitive:   true,
 						Description: "The pre shared secret for L2TP/IPsec",
 						Validators: []validator.String{
 							stringvalidator.LengthBetween(0, 40),
+							stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("l2tp").AtName("pre_shared_secret_wo")),
+							stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("pre_shared_secret_wo")),
+						},
+					},
+					"pre_shared_secret_wo": schema.StringAttribute{
+						Optional:    true,
+						WriteOnly:   true,
+						Description: "The pre shared secret for L2TP/IPsec",
+						Validators: []validator.String{
+							stringvalidator.LengthBetween(0, 40),
+							stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("pre_shared_secret")),
+							stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("pre_shared_secret_wo_version")),
+						},
+					},
+					"pre_shared_secret_wo_version": schema.Int32Attribute{
+						Optional:    true,
+						Description: "The version of the pre_shared_secret_wo field. This value must be greater than 0 when set. Increment this when changing pre_shared_secret_wo.",
+						Validators: []validator.Int32{
+							int32validator.AtLeast(1),
+							int32validator.AlsoRequires(path.MatchRelative().AtParent().AtName("pre_shared_secret_wo")),
 						},
 					},
 					"range_start": schema.StringAttribute{
@@ -468,11 +509,31 @@ func (d *vpnRouterResource) Schema(ctx context.Context, _ resource.SchemaRequest
 							Description: "The id of the opposing appliance connected to the VPN Router. This is typically set same as value of `peer`",
 						},
 						"pre_shared_secret": schema.StringAttribute{
-							Required:    true,
+							Optional:    true,
 							Sensitive:   true,
 							Description: desc.Sprintf("The pre shared secret for the VPN. %s", desc.Length(0, 40)),
 							Validators: []validator.String{
 								stringvalidator.LengthBetween(0, 40),
+								stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("site_to_site_vpn").AtAnyListIndex().AtName("pre_shared_secret_wo")),
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("pre_shared_secret_wo")),
+							},
+						},
+						"pre_shared_secret_wo": schema.StringAttribute{
+							Optional:    true,
+							WriteOnly:   true,
+							Description: desc.Sprintf("The pre shared secret for the VPN. %s", desc.Length(0, 40)),
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(0, 40),
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("pre_shared_secret")),
+								stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("pre_shared_secret_wo_version")),
+							},
+						},
+						"pre_shared_secret_wo_version": schema.Int32Attribute{
+							Optional:    true,
+							Description: "The version of the pre_shared_secret_wo field. This value must be greater than 0 when set. Increment this when changing pre_shared_secret_wo.",
+							Validators: []validator.Int32{
+								int32validator.AtLeast(1),
+								int32validator.AlsoRequires(path.MatchRelative().AtParent().AtName("pre_shared_secret_wo")),
 							},
 						},
 						"routes": schema.ListAttribute{
@@ -791,7 +852,7 @@ func (r *vpnRouterResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	if rmResource, err := plan.updateState(ctx, r.client, zone, vpnRouter); err != nil {
+	if rmResource, err := plan.updateModel(ctx, r.client, zone, vpnRouter); err != nil {
 		if rmResource {
 			resp.State.RemoveResource(ctx)
 		}
@@ -852,4 +913,78 @@ func getRouter(ctx context.Context, client *common.APIClient, zone string, id ia
 		return nil
 	}
 	return vpnRouter
+}
+
+func (model *vpnRouterResourceModel) updateModel(ctx context.Context, client *common.APIClient, zone string, vpnRouter *iaas.VPCRouter) (bool, error) {
+	if rmResource, err := model.updateState(ctx, client, zone, vpnRouter); err != nil {
+		return rmResource, err
+	}
+
+	previousS2SVersions := map[string]types.Int32{}
+	for _, s := range model.SiteToSiteVPN {
+		peer := s.Peer.ValueString()
+		if peer == "" {
+			continue
+		}
+		if utils.IsKnown(s.PreSharedSecretWOVersion) {
+			previousS2SVersions[peer] = s.PreSharedSecretWOVersion
+		}
+	}
+
+	model.L2TP = flattenVPNRouterL2TP(vpnRouter, model.L2TP)
+	model.SiteToSiteVPN = flattenVPNRouterSiteToSiteConfig(vpnRouter, model.SiteToSiteVPN)
+
+	return false, nil
+}
+
+func flattenVPNRouterL2TP(vpcRouter *iaas.VPCRouter, previousL2TP *vpnRouterL2TPModel) *vpnRouterL2TPModel {
+	if vpcRouter.Settings.L2TPIPsecServerEnabled.Bool() {
+		pre := types.StringNull()
+		preVer := types.Int32Null()
+		if previousL2TP != nil {
+			if utils.IsKnown(previousL2TP.PreSharedSecretWOVersion) {
+				preVer = types.Int32Value(previousL2TP.PreSharedSecretWOVersion.ValueInt32())
+			} else {
+				// PreSharedSecretは将来的にレスポンスから削除されるため、レスポンスではなく設定の値を引き継ぐ
+				pre = types.StringValue(previousL2TP.PreSharedSecret.ValueString())
+			}
+		}
+		m := vpnRouterL2TPModel{
+			PreSharedSecret:          pre,
+			PreSharedSecretWOVersion: preVer,
+			RangeStart:               types.StringValue(vpcRouter.Settings.L2TPIPsecServer.RangeStart),
+			RangeStop:                types.StringValue(vpcRouter.Settings.L2TPIPsecServer.RangeStop),
+		}
+		return &m
+	}
+	return nil
+}
+
+func flattenVPNRouterSiteToSiteConfig(vpcRouter *iaas.VPCRouter, confs []vpnRouterSiteToSiteVPNModel) []vpnRouterSiteToSiteVPNModel {
+	var s2sSettings []vpnRouterSiteToSiteVPNModel
+	if vpcRouter.Settings.SiteToSiteIPsecVPN != nil {
+		for _, s := range vpcRouter.Settings.SiteToSiteIPsecVPN.Config {
+			pre := types.StringNull()
+			preVer := types.Int32Null()
+			for _, c := range confs {
+				if c.Peer.ValueString() == s.Peer {
+					if utils.IsKnown(c.PreSharedSecretWOVersion) {
+						preVer = types.Int32Value(c.PreSharedSecretWOVersion.ValueInt32())
+					} else {
+						// PreSharedSecretは将来的にレスポンスから削除されるため、レスポンスではなく設定の値を引き継ぐ
+						pre = types.StringValue(c.PreSharedSecret.ValueString())
+					}
+				}
+			}
+			s2sSettings = append(s2sSettings, vpnRouterSiteToSiteVPNModel{
+				Peer:                     types.StringValue(s.Peer),
+				RemoteID:                 types.StringValue(s.RemoteID),
+				PreSharedSecret:          pre,
+				PreSharedSecretWOVersion: preVer,
+				Routes:                   common.StringsToTlist(s.Routes),
+				LocalPrefix:              common.StringsToTlist(s.LocalPrefix),
+			})
+		}
+	}
+	return s2sSettings
 }

--- a/internal/service/vpn_router/resource_test.go
+++ b/internal/service/vpn_router/resource_test.go
@@ -206,6 +206,69 @@ func TestAccSakuraVPNRouter_Full(t *testing.T) {
 	})
 }
 
+func TestAccSakuraVPNRouter_WOFull(t *testing.T) {
+	resourceName := "sakura_vpn_router.foobar"
+	rand := test.RandomName()
+
+	var vpcRouter iaas.VPCRouter
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			test.CheckSakuraInternetDestroy,
+			test.CheckSakuravSwitchDestroy,
+			testCheckSakuraVPNRouterDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraVPNRouter_fullWithWO, rand),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraVPNRouterExists(resourceName, &vpcRouter),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "version", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_netmask"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.0.vip", "192.168.11.1"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.0.ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.0.ip_addresses.0", "192.168.11.2"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.0.ip_addresses.1", "192.168.11.3"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.0.netmask", "24"),
+					resource.TestCheckNoResourceAttr(resourceName, "l2tp.pre_shared_secret_wo"),
+					resource.TestCheckResourceAttr(resourceName, "l2tp.pre_shared_secret_wo_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "l2tp.range_start", "192.168.11.21"),
+					resource.TestCheckResourceAttr(resourceName, "l2tp.range_stop", "192.168.11.30"),
+					resource.TestCheckResourceAttr(resourceName, "pptp.range_start", "192.168.11.31"),
+					resource.TestCheckResourceAttr(resourceName, "pptp.range_stop", "192.168.11.40"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn.0.peer", "8.8.8.8"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn.0.remote_id", "8.8.8.8"),
+					resource.TestCheckNoResourceAttr(resourceName, "site_to_site_vpn.0.pre_shared_secret_wo"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn.0.pre_shared_secret_wo_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn.0.routes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn.0.routes.0", "10.0.0.0/8"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn.0.local_prefix.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn.0.local_prefix.0", "192.168.21.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn_parameter.ike.lifetime", "28801"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn_parameter.ike.dpd.interval", "16"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn_parameter.ike.dpd.timeout", "31"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn_parameter.esp.lifetime", "1801"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn_parameter.encryption_algo", "aes256"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn_parameter.hash_algo", "sha256"),
+					resource.TestCheckResourceAttr(resourceName, "site_to_site_vpn_parameter.dh_group", "modp2048"),
+					resource.TestCheckResourceAttr(resourceName, "static_nat.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "static_nat.0.public_ip", "sakura_internet.foobar", "ip_addresses.3"),
+					resource.TestCheckResourceAttr(resourceName, "static_nat.0.private_ip", "192.168.11.12"),
+					resource.TestCheckResourceAttr(resourceName, "static_nat.0.description", "desc"),
+					resource.TestCheckResourceAttr(resourceName, "user.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user.0.name", "username"),
+					resource.TestCheckResourceAttr(resourceName, "user.0.password_wo_version", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckSakuraVPNRouterExists(n string, vpcRouter *iaas.VPCRouter) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -469,5 +532,89 @@ resource "sakura_vpn_router" "foobar" {
     aliases      = [sakura_internet.foobar.ip_addresses[3]]
     vrid         = 1
   }
+}
+`
+
+var testAccSakuraVPNRouter_fullWithWO = `
+resource "sakura_internet" "foobar" {
+  name = "{{ .arg0 }}"
+}
+resource "sakura_vswitch" "foobar" {
+  name = "{{ .arg0 }}"
+}
+
+resource "sakura_vpn_router" "foobar" {
+  name        = "{{ .arg0 }}"
+  description = "description"
+  tags        = ["tag1" , "tag2"]
+  plan        = "premium"
+  version     = 2
+
+  internet_connection = true
+
+  public_network_interface = {
+    vswitch_id   = sakura_internet.foobar.vswitch_id
+    vip          = sakura_internet.foobar.ip_addresses[0]
+    ip_addresses = [sakura_internet.foobar.ip_addresses[1], sakura_internet.foobar.ip_addresses[2]]
+    aliases      = [sakura_internet.foobar.ip_addresses[3]]
+    vrid         = 1
+  }
+
+  private_network_interface = [{
+    index        = 1
+    vswitch_id   = sakura_vswitch.foobar.id
+    vip          = "192.168.11.1"
+    ip_addresses = ["192.168.11.2", "192.168.11.3"]
+    netmask      = 24
+  }]
+
+  l2tp = {
+    range_start = "192.168.11.21"
+    range_stop  = "192.168.11.30"
+    pre_shared_secret_wo = "example"
+	pre_shared_secret_wo_version = 1
+  }
+
+  pptp = {
+    range_start = "192.168.11.31"
+    range_stop  = "192.168.11.40"
+  }
+
+  site_to_site_vpn = [{
+    peer         = "8.8.8.8"
+    remote_id    = "8.8.8.8"
+    routes       = ["10.0.0.0/8"]
+    local_prefix = ["192.168.21.0/24"]
+    pre_shared_secret_wo = "example"
+	pre_shared_secret_wo_version = 1
+  }]
+
+  site_to_site_vpn_parameter = {
+    ike = {
+      lifetime = 28801
+      dpd = {
+        interval = 16
+        timeout  = 31
+      }
+    }
+    esp = {
+      lifetime = 1801
+    }
+    encryption_algo = "aes256"
+    hash_algo       = "sha256"
+    dh_group        = "modp2048"
+  }
+
+  static_nat = [{
+    public_ip   = sakura_internet.foobar.ip_addresses[3]
+    private_ip  = "192.168.11.12"
+    description = "desc"
+  }]
+
+  user = [{
+    name                = "username"
+	password_wo         = "password"
+	password_wo_version = 1
+  }]
 }
 `

--- a/internal/service/vpn_router/structure.go
+++ b/internal/service/vpn_router/structure.go
@@ -134,10 +134,10 @@ func expandVPNRouterSettings(model, config *vpnRouterResourceModel) *builder.Rou
 		DHCPStaticMapping:         expandVPNRouterDHCPStaticMappingList(model),
 		DNSForwarding:             expandVPNRouterDNSForwarding(model),
 		PPTPServer:                expandVPNRouterPPTP(model),
-		L2TPIPsecServer:           expandVPNRouterL2TP(model),
+		L2TPIPsecServer:           expandVPNRouterL2TP(model, config),
 		RemoteAccessUsers:         expandVPNRouterUserList(model, config),
 		WireGuard:                 expandVPNRouterWireGuard(model),
-		SiteToSiteIPsecVPN:        expandVPNRouterSiteToSite(model),
+		SiteToSiteIPsecVPN:        expandVPNRouterSiteToSite(model, config),
 		StaticRoute:               expandVPNRouterStaticRouteList(model),
 		SyslogHost:                model.SyslogHost.ValueString(),
 		ScheduledMaintenance:      expandVPNRouterScheduledMaintenance(model),
@@ -322,21 +322,22 @@ func expandVPNRouterPPTP(model *vpnRouterResourceModel) *iaas.VPCRouterPPTPServe
 	}
 }
 
-func expandVPNRouterL2TP(model *vpnRouterResourceModel) *iaas.VPCRouterL2TPIPsecServer {
-	if model.L2TP.IsNull() || model.L2TP.IsUnknown() {
+func expandVPNRouterL2TP(model, config *vpnRouterResourceModel) *iaas.VPCRouterL2TPIPsecServer {
+	if model.L2TP == nil {
 		return nil
 	}
 
-	var d vpnRouterL2TPModel
-	diags := model.L2TP.As(context.Background(), &d, basetypes.ObjectAsOptions{})
-	if diags.HasError() {
-		return nil
+	preSharedSecret := model.L2TP.PreSharedSecret.ValueString()
+	if config != nil && config.L2TP != nil {
+		if config.L2TP.PreSharedSecretWO.ValueString() != "" {
+			preSharedSecret = config.L2TP.PreSharedSecretWO.ValueString()
+		}
 	}
 
 	return &iaas.VPCRouterL2TPIPsecServer{
-		RangeStart:      d.RangeStart.ValueString(),
-		RangeStop:       d.RangeStop.ValueString(),
-		PreSharedSecret: d.PreSharedSecret.ValueString(),
+		RangeStart:      model.L2TP.RangeStart.ValueString(),
+		RangeStop:       model.L2TP.RangeStop.ValueString(),
+		PreSharedSecret: preSharedSecret,
 	}
 }
 
@@ -389,11 +390,11 @@ func expandVPNRouterPortForwarding(model *vpnRouterPortForwardingModel) *iaas.VP
 	}
 }
 
-func expandVPNRouterSiteToSite(model *vpnRouterResourceModel) *iaas.VPCRouterSiteToSiteIPsecVPN {
+func expandVPNRouterSiteToSite(model, config *vpnRouterResourceModel) *iaas.VPCRouterSiteToSiteIPsecVPN {
 	siteToSiteVPN := &iaas.VPCRouterSiteToSiteIPsecVPN{}
 	if values := model.SiteToSiteVPN; len(values) > 0 {
-		for _, v := range values {
-			siteToSiteVPN.Config = append(siteToSiteVPN.Config, expandVPNRouterSiteToSiteConfig(&v))
+		for i, v := range values {
+			siteToSiteVPN.Config = append(siteToSiteVPN.Config, expandVPNRouterSiteToSiteConfig(&v, config, i))
 		}
 	}
 
@@ -416,11 +417,19 @@ func expandVPNRouterSiteToSite(model *vpnRouterResourceModel) *iaas.VPCRouterSit
 	return siteToSiteVPN
 }
 
-func expandVPNRouterSiteToSiteConfig(model *vpnRouterSiteToSiteVPNModel) *iaas.VPCRouterSiteToSiteIPsecVPNConfig {
+func expandVPNRouterSiteToSiteConfig(model *vpnRouterSiteToSiteVPNModel, config *vpnRouterResourceModel, index int) *iaas.VPCRouterSiteToSiteIPsecVPNConfig {
+	preSharedSecret := model.PreSharedSecret.ValueString()
+	if config != nil && index < len(config.SiteToSiteVPN) {
+		cfg := config.SiteToSiteVPN[index]
+		if cfg.PreSharedSecretWO.ValueString() != "" {
+			preSharedSecret = cfg.PreSharedSecretWO.ValueString()
+		}
+	}
+
 	return &iaas.VPCRouterSiteToSiteIPsecVPNConfig{
 		Peer:            model.Peer.ValueString(),
 		RemoteID:        model.RemoteID.ValueString(),
-		PreSharedSecret: model.PreSharedSecret.ValueString(),
+		PreSharedSecret: preSharedSecret,
 		Routes:          common.TlistToStringsOrDefault(model.Routes),
 		LocalPrefix:     common.TlistToStringsOrDefault(model.LocalPrefix),
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

将来的にAPIがレスポンスを返さなくなるフィールド群や、WriteOnlyが望ましいフィールド群に関して修正。
WriteOnlyに移行可能なものはWriteOnly版を提供。また、現状のterraformの制約でWriteOnlyに移行できないものに関しては、レスポンスを使わずに既存の設定・状態から値を使うよう修正(container_registry/enhanced_lb)。
Data Source等に関しては、フィールドは維持しているものの`null` / `""`を設定することで互換性を維持。

また、既存の実装が無駄に複雑だったものに関してはよりシンプルな実装に修正(vpn_router等)。
local_routerのテストに関しては、将来的に値が取得できなくなるsecret_keysに依存していたため、外部から既存のリソースを指定する方式に変更し、より単純なテストにしました。

### ドキュメントの変更は必要ですか？

レビュー後ドキュメントを生成。