### PR TITLE
fix: mark object_storage_permission access_key and secret_key as Sensitive

### DIFF
--- a/docs/resources/object_storage_permission.md
+++ b/docs/resources/object_storage_permission.md
@@ -39,9 +39,9 @@ resource "sakura_object_storage_permission" "foobar" {
 
 ### Read-Only
 
-- `access_key` (String) The access key for the Object Storage Permission.
+- `access_key` (String, Sensitive) The access key for the Object Storage Permission.
 - `id` (String) The ID of the Object Storage Permission.
-- `secret_key` (String) The secret key for the Object Storage Permission.
+- `secret_key` (String, Sensitive) The secret key for the Object Storage Permission.
 
 <a id="nestedatt--bucket_controls"></a>
 ### Nested Schema for `bucket_controls`

--- a/internal/service/object_storage/resource_permission.go
+++ b/internal/service/object_storage/resource_permission.go
@@ -75,10 +75,12 @@ func (r *objectStoragePermissionResource) Schema(ctx context.Context, _ resource
 			},
 			"access_key": schema.StringAttribute{
 				Computed:    true,
+				Sensitive:   true,
 				Description: "The access key for the Object Storage Permission.",
 			},
 			"secret_key": schema.StringAttribute{
 				Computed:    true,
+				Sensitive:   true,
 				Description: "The secret key for the Object Storage Permission.",
 			},
 			"bucket_controls": schema.ListNestedAttribute{


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

`object_storage_permission` リソースの `access_key` と `secret_key` に `Sensitive: true` を追加しました。
生成ドキュメントも `make generate-docs` で更新しています。

### ドキュメントの変更は必要ですか？

`make generate-docs` により自動生成済みです。