### PR TITLE
fix: correct subscription destroy check in workflows tests

### DIFF
--- a/internal/service/workflows/resource_subscription_test.go
+++ b/internal/service/workflows/resource_subscription_test.go
@@ -59,8 +59,11 @@ func testCheckSakuraWorkflowsSubscriptionDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := subscriptionOp.Read(context.Background())
-		if err == nil {
+		data, err := subscriptionOp.Read(context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to read subscription: %s", rs.Primary.ID)
+		}
+		if !data.CurrentPlan.IsNull() { // NOTE: 当月中はサブスクリプションを削除してもMonthAppliedPlanの値が返る。判定にはCurrentPlanがnullかを見る必要あり
 			return fmt.Errorf("subscription still exists: %s", rs.Primary.ID)
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

workflowsのsubscriptionリソーステストにおいて、削除後の存在確認が正しく行えていなかった問題を修正した。

- サブスクリプションは削除後も当月内はAPIからデータが返る（MonthAppliedPlanが残る）
- そのため、従来の`err == nil`での存在判定では誤って「まだ存在する」と判定されていた
- 正しく削除されたかを確認するために`CurrentPlan.IsNull()`で判定するように変更した

### ドキュメントの変更は必要ですか？

不要