### PR TITLE
object_storage: Automatic account creation when account not exist

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -234,7 +234,7 @@ func (p *sakuraProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	var keyKID string
 	if utils.IsKnown(config.ServicePrincipalKeyKID) {
 		keyKID = config.ServicePrincipalKeyKID.ValueString()
-	} else {
+	} else if utils.IsKnown(config.ServicePrincipalKeyID) {
 		resp.Diagnostics.AddWarning("Deprecated Configuration", "The `service_principal_key_id` attribute is deprecated and will be removed in the future. Use `service_principal_key_kid` instead.")
 		keyKID = config.ServicePrincipalKeyID.ValueString()
 	}

--- a/internal/service/object_storage/resource_bucket.go
+++ b/internal/service/object_storage/resource_bucket.go
@@ -113,6 +113,11 @@ func (r *objectStorageBucketResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
+	if err := createAccountIfNotExist(ctx, siteClient); err != nil {
+		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to ensure Object Storage account exists: %s", err))
+		return
+	}
+
 	bucketAPI := objectstorage.NewBucketOp(r.fedClient, siteClient)
 	bucket, err := bucketAPI.Create(ctx, &objectstorage.BucketCreateParams{Bucket: plan.Name.ValueString(), SiteId: siteId})
 	if err != nil {
@@ -176,4 +181,21 @@ func (r *objectStorageBucketResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("Delete: API Error", fmt.Sprintf("failed to delete Object Storage Bucket: %s", err))
 		return
 	}
+}
+
+// コンパネからサイトにアクセスするとアカウントが自動で作られるが、terraformだけで管理している場合にはアカウントが存在しない可能性があるため、必要に応じて作成する
+func createAccountIfNotExist(ctx context.Context, client *objectstorage.SiteClient) error {
+	accountOp := objectstorage.NewAccountOp(client)
+	_, err := accountOp.Read(ctx)
+	if err != nil {
+		if saclient.IsNotFoundError(err) {
+			_, err = accountOp.Create(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to create Object Storage account: %w", err)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to read Object Storage account: %w", err)
+	}
+	return nil
 }

--- a/internal/service/object_storage/resource_permission.go
+++ b/internal/service/object_storage/resource_permission.go
@@ -138,6 +138,11 @@ func (r *objectStoragePermissionResource) Create(ctx context.Context, req resour
 		return
 	}
 
+	if err := createAccountIfNotExist(ctx, siteClient); err != nil {
+		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to ensure Object Storage account exists: %s", err))
+		return
+	}
+
 	permissionOp := objectstorage.NewPermissionOp(siteClient)
 	permission, err := permissionOp.Create(ctx, plan.Name.ValueString(), getBucketControls(&plan))
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

terraformだけでオブジェクトストレージを管理している場合、アカウントが存在しないサイトに対して処理を行うことが起きうるので、そういう場合には自動でアカウントを作る処理を挟む。
objectリソースに関しては他にPermission/Bucketを作ってから使うリソースなので処理を入れていない。

また追加でいらないwarningが出るようになってたのでそれ向けのone-line修正も込み。

### ドキュメントの変更は必要ですか？

おそらく必要無し。