### PR TITLE
apprun-api-go v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/sacloud/addon-api-go v0.1.0
 	github.com/sacloud/api-client-go v0.3.5
 	github.com/sacloud/apigw-api-go v0.3.0
-	github.com/sacloud/apprun-api-go v0.7.1
+	github.com/sacloud/apprun-api-go v0.8.0
 	github.com/sacloud/apprun-dedicated-api-go v0.2.0
 	github.com/sacloud/autoscaler v0.19.3
 	github.com/sacloud/cloudhsm-api-go v0.4.0
@@ -48,7 +48,6 @@ require (
 require (
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -109,8 +108,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/oapi-codegen/runtime v1.1.2 // indirect
-	github.com/ogen-go/ogen v1.20.2 // indirect
+	github.com/ogen-go/ogen v1.20.3 // indirect
 	github.com/oklog/run v1.2.0 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
-github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
@@ -16,7 +13,6 @@ github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/c-robinson/iplib v1.0.8 h1:exDRViDyL9UBLcfmlxxkY5odWX5092nPsQIykHXhIn4=
@@ -163,7 +159,6 @@ github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5Xum
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/jlaffaye/ftp v0.2.0 h1:lXNvW7cBu7R/68bknOX3MrRIIqZ61zELs1P2RAiA3lg=
 github.com/jlaffaye/ftp v0.2.0/go.mod h1:is2Ds5qkhceAPy2xD6RLI6hmp/qysSoymZ+Z2uTnspI=
-github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
@@ -212,10 +207,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQgXIyI=
-github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
-github.com/ogen-go/ogen v1.20.2 h1:mEZGPST7ZeX84AkqRlFawDLwcwuzcLO5PtYpAXLT1YE=
-github.com/ogen-go/ogen v1.20.2/go.mod h1:sJ1pJVp4S1RcSZlYIiMLo0QSMSt2pls4zfrc+hNKnzk=
+github.com/ogen-go/ogen v1.20.3 h1:1tvJuJE0BnQ7Nukd6ykiTOP0ucfL0yrAjHUg3S1DCQk=
+github.com/ogen-go/ogen v1.20.3/go.mod h1:sJ1pJVp4S1RcSZlYIiMLo0QSMSt2pls4zfrc+hNKnzk=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
@@ -243,8 +236,8 @@ github.com/sacloud/api-client-go v0.3.5 h1:0ALibvbC+6MBhN7t61k+RhguhiEQ8+NejqBjq
 github.com/sacloud/api-client-go v0.3.5/go.mod h1:akdcCOl6wszywa0YQ5X8cMnNgWTm+7N4EneODTdiH48=
 github.com/sacloud/apigw-api-go v0.3.0 h1:dxrV2L6/SNdRM0dLJm+p9d40bOWopVYmykD8TAJL1qY=
 github.com/sacloud/apigw-api-go v0.3.0/go.mod h1:YtaZ7lYtjwI4PrnrVvYStQEjrb2lTbyac/L95giqApg=
-github.com/sacloud/apprun-api-go v0.7.1 h1:Kc0Xa9sveiXFRYJ0e9NtRRj9AI36yG5RFuQYjDNJ4Qo=
-github.com/sacloud/apprun-api-go v0.7.1/go.mod h1:0vQhVsP/5QWui5yJsYjV7cf35tESEHdv84dGSt6qZuE=
+github.com/sacloud/apprun-api-go v0.8.0 h1:VT64rGY9gV9fkWiq4On4/zlp6LO8RGEL9EtdLOzXMyc=
+github.com/sacloud/apprun-api-go v0.8.0/go.mod h1:rqwzv6jKBzRNwL29jD8oFVdLoiFy9WgFzrInOR1iO9c=
 github.com/sacloud/apprun-dedicated-api-go v0.2.0 h1:UUHDclY5Po8V7HuSzKwHdzVCkCD7VkNVoD2f+2O1Ptc=
 github.com/sacloud/apprun-dedicated-api-go v0.2.0/go.mod h1:znwpgRva+AKZ2lrBN7F+2jlWhqfLqEt4ZNQp6LbZ9vA=
 github.com/sacloud/autoscaler v0.19.3 h1:FkBxc0mE8fvaWiOiz+TpFAT1TX8DRLXs8prsqaM2MF0=
@@ -303,9 +296,7 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sacloud/apigw-api-go"
 	apigwapi "github.com/sacloud/apigw-api-go/apis/v1"
 	"github.com/sacloud/apprun-api-go"
+	apprunapi "github.com/sacloud/apprun-api-go/apis/v1"
 	apprun_dedicated "github.com/sacloud/apprun-dedicated-api-go"
 	apprundedicatedapi "github.com/sacloud/apprun-dedicated-api-go/apis/v1"
 	dedicatedstorage "github.com/sacloud/dedicated-storage-api-go"
@@ -111,7 +112,7 @@ type APIClient struct {
 	vpcRouterWaitAfterCreateDuration time.Duration
 	CallerOptions                    *client.Options
 	SaClient                         *saclient.Client
-	AppRunClient                     *apprun.Client
+	AppRunClient                     *apprunapi.Client
 	AppRunDedicatedClient            *apprundedicatedapi.Client
 	KmsClient                        *kmsapi.Client
 	SecretManagerClient              *smapi.Client
@@ -401,6 +402,10 @@ func (c *Config) NewClient(envConf *Config) (*APIClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	apprunClient, err := apprun.NewClient(theClient)
+	if err != nil {
+		return nil, err
+	}
 	kmsClient, err := kms.NewClient(theClient)
 	if err != nil {
 		return nil, err
@@ -472,7 +477,7 @@ func (c *Config) NewClient(envConf *Config) (*APIClient, error) {
 		SecretManagerClient:              smClient,
 		SimpleMqClient:                   simplemqClient,
 		EventBusClient:                   eventbusClient,
-		AppRunClient:                     &apprun.Client{Saclient: theClient},
+		AppRunClient:                     apprunClient,
 		AppRunDedicatedClient:            apprundedicatedClient,
 		ObjectStorageFedClient:           fedClient,
 		NosqlClient:                      nosqlClient,

--- a/internal/service/apprun_shared/data_source.go
+++ b/internal/service/apprun_shared/data_source.go
@@ -16,7 +16,7 @@ import (
 )
 
 type apprunSharedDataSource struct {
-	client *apprun.Client
+	client *v1.Client
 }
 
 var (
@@ -241,10 +241,10 @@ func (d *apprunSharedDataSource) Read(ctx context.Context, req datasource.ReadRe
 	}
 
 	name := data.Name.ValueString()
-	var app *v1.Application
+	var app *v1.HandlerGetApplication
 	for _, d := range apps.Data {
 		if d.Name == name {
-			a, err := appOp.Read(ctx, d.Id)
+			a, err := appOp.Read(ctx, d.ID)
 			if err != nil {
 				resp.Diagnostics.AddError("Read: API Error", fmt.Sprintf("failed to read AppRun Shared resource: %s", err))
 				return
@@ -259,7 +259,7 @@ func (d *apprunSharedDataSource) Read(ctx context.Context, req datasource.ReadRe
 	}
 
 	pfOp := apprun.NewPacketFilterOp(d.client)
-	pf, err := pfOp.Read(ctx, app.Id)
+	pf, err := pfOp.Read(ctx, app.ID)
 	if err != nil {
 		resp.Diagnostics.AddError("Read: API Error", fmt.Sprintf("failed to read AppRun Shared's PacketFilter resource: %s", err))
 		return

--- a/internal/service/apprun_shared/model.go
+++ b/internal/service/apprun_shared/model.go
@@ -119,9 +119,16 @@ func (m apprunSharedPacketFilterSettingsModel) AttributeTypes() map[string]attr.
 	}
 }
 
-func (model *apprunSharedBaseModel) updateState(application *v1.Application, pf *v1.HandlerGetPacketFilter) {
-	model.ID = types.StringValue(application.Id)
-	model.ResourceID = types.StringValue(application.ResourceId)
+func stringValueFromOptString(value v1.OptString) types.String {
+	if v, ok := value.Get(); ok {
+		return types.StringValue(v)
+	}
+	return types.StringNull()
+}
+
+func (model *apprunSharedBaseModel) updateState(application *v1.HandlerGetApplication, pf *v1.HandlerGetPacketFilter) {
+	model.ID = types.StringValue(application.ID)
+	model.ResourceID = types.StringValue(application.ResourceID)
 	model.Name = types.StringValue(application.Name)
 	model.TimeoutSeconds = types.Int32Value(int32(application.TimeoutSeconds))
 	model.Port = types.Int32Value(int32(application.Port))
@@ -130,23 +137,26 @@ func (model *apprunSharedBaseModel) updateState(application *v1.Application, pf 
 	model.Components = flattenApprunApplicationComponents(model, application, true)
 	model.PacketFilter = flattenApprunPacketFilter(pf)
 	model.Status = types.StringValue(string(application.Status))
-	model.PublicURL = types.StringValue(application.PublicUrl)
+	model.PublicURL = types.StringValue(application.PublicURL)
 }
 
-func flattenApprunApplicationComponents(model *apprunSharedBaseModel, application *v1.Application, includePassword bool) []*apprunSharedComponentModel {
+func flattenApprunApplicationComponents(model *apprunSharedBaseModel, application *v1.HandlerGetApplication, includePassword bool) []*apprunSharedComponentModel {
 	var results []*apprunSharedComponentModel
 
 	for _, c := range application.Components {
+		containerRegistry := &apprunSharedComponentContainerRegistryModel{}
+		if cr, ok := c.DeploySource.ContainerRegistry.Get(); ok {
+			containerRegistry.Image = types.StringValue(cr.Image)
+			containerRegistry.Server = stringValueFromOptString(cr.Server)
+			containerRegistry.Username = stringValueFromOptString(cr.Username)
+		}
+
 		result := &apprunSharedComponentModel{
 			Name:      types.StringValue(c.Name),
-			MaxCpu:    types.StringValue(c.MaxCpu),
+			MaxCpu:    types.StringValue(c.MaxCPU),
 			MaxMemory: types.StringValue(c.MaxMemory),
 			DeploySource: &apprunSharedComponentDeploySourceModel{
-				ContainerRegistry: &apprunSharedComponentContainerRegistryModel{
-					Image:    types.StringValue(c.DeploySource.ContainerRegistry.Image),
-					Server:   types.StringValue(*c.DeploySource.ContainerRegistry.Server),
-					Username: types.StringValue(*c.DeploySource.ContainerRegistry.Username),
-				},
+				ContainerRegistry: containerRegistry,
 			},
 			Env:   flattenApprunApplicationEnvs(&c),
 			Probe: flattenApprunApplicationProbe(&c),
@@ -176,16 +186,16 @@ func flattenApprunApplicationComponents(model *apprunSharedBaseModel, applicatio
 	return results
 }
 
-func flattenApprunApplicationEnvs(component *v1.HandlerApplicationComponent) types.Set {
-	if component.Env == nil || len(*component.Env) == 0 {
+func flattenApprunApplicationEnvs(component *v1.HandlerGetApplicationComponentsItem) types.Set {
+	if len(component.Env) == 0 {
 		return types.SetNull(types.ObjectType{AttrTypes: apprunSharedComponentEnvModel{}.AttributeTypes()})
 	}
 
 	var results []apprunSharedComponentEnvModel
-	for _, e := range *component.Env {
+	for _, e := range component.Env {
 		results = append(results, apprunSharedComponentEnvModel{
-			Key:   types.StringValue(*e.Key),
-			Value: types.StringValue(*e.Value),
+			Key:   stringValueFromOptString(e.Key),
+			Value: stringValueFromOptString(e.Value),
 		})
 	}
 
@@ -197,14 +207,19 @@ func toTSet(elemType map[string]attr.Type, elem any) types.Set {
 	return r
 }
 
-func flattenApprunApplicationProbe(component *v1.HandlerApplicationComponent) types.Object {
+func flattenApprunApplicationProbe(component *v1.HandlerGetApplicationComponentsItem) types.Object {
 	v := types.ObjectNull(apprunSharedProbeModel{}.AttributeTypes())
-	if component.Probe != nil && component.Probe.HttpGet != nil {
+	probe, ok := component.Probe.Get()
+	if ok {
+		httpGet, ok := probe.HTTPGet.Get()
+		if !ok {
+			return v
+		}
 		m := apprunSharedProbeModel{
 			HttpGet: &apprunSharedProbeHttpGetModel{
-				Path:    types.StringValue(component.Probe.HttpGet.Path),
-				Port:    types.Int32Value(int32(component.Probe.HttpGet.Port)),
-				Headers: flattenApprunApplicationProbeHttpGetHeaders(component),
+				Path:    types.StringValue(httpGet.Path),
+				Port:    types.Int32Value(int32(httpGet.Port)),
+				Headers: flattenApprunApplicationProbeHttpGetHeaders(&httpGet),
 			},
 		}
 		value, diags := types.ObjectValueFrom(context.Background(), m.AttributeTypes(), m)
@@ -216,16 +231,16 @@ func flattenApprunApplicationProbe(component *v1.HandlerApplicationComponent) ty
 	return v
 }
 
-func flattenApprunApplicationProbeHttpGetHeaders(component *v1.HandlerApplicationComponent) types.Set {
-	if component.Probe.HttpGet.Headers == nil || len(*component.Probe.HttpGet.Headers) == 0 {
+func flattenApprunApplicationProbeHttpGetHeaders(httpGet *v1.HandlerGetApplicationComponentsItemProbeHTTPGet) types.Set {
+	if len(httpGet.Headers) == 0 {
 		return types.SetNull(types.ObjectType{AttrTypes: apprunSharedProbeHttpGetHeaderModel{}.AttributeTypes()})
 	}
 
 	var results []apprunSharedProbeHttpGetHeaderModel
-	for _, h := range *component.Probe.HttpGet.Headers {
+	for _, h := range httpGet.Headers {
 		results = append(results, apprunSharedProbeHttpGetHeaderModel{
-			Name:  types.StringValue(*h.Name),
-			Value: types.StringValue(*h.Value),
+			Name:  stringValueFromOptString(h.Name),
+			Value: stringValueFromOptString(h.Value),
 		})
 	}
 
@@ -243,12 +258,12 @@ func flattenApprunPacketFilter(packetFilter *v1.HandlerGetPacketFilter) *apprunS
 	}
 }
 
-func flattenApprunPacketFilterSettings(settings []v1.PacketFilterSetting) []*apprunSharedPacketFilterSettingsModel {
+func flattenApprunPacketFilterSettings(settings []v1.HandlerGetPacketFilterSettingsItem) []*apprunSharedPacketFilterSettingsModel {
 	var results []*apprunSharedPacketFilterSettingsModel
 	for _, s := range settings {
 		results = append(results, &apprunSharedPacketFilterSettingsModel{
-			FromIP:             types.StringValue(s.FromIp),
-			FromIPPrefixLength: types.Int32Value(int32(s.FromIpPrefixLength)),
+			FromIP:             types.StringValue(s.FromIP),
+			FromIPPrefixLength: types.Int32Value(int32(s.FromIPPrefixLength)),
 		})
 	}
 	return results

--- a/internal/service/apprun_shared/resource.go
+++ b/internal/service/apprun_shared/resource.go
@@ -6,7 +6,6 @@ package apprun_shared
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
@@ -23,12 +22,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/sacloud/apprun-api-go"
 	v1 "github.com/sacloud/apprun-api-go/apis/v1"
+	"github.com/sacloud/saclient-go"
 	"github.com/sacloud/terraform-provider-sakura/internal/common"
 	"github.com/sacloud/terraform-provider-sakura/internal/desc"
 )
 
 type apprunSharedResource struct {
-	client *apprun.Client
+	client *v1.Client
 }
 
 var (
@@ -332,13 +332,13 @@ func (r *apprunSharedResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	pfOp := apprun.NewPacketFilterOp(r.client)
-	if _, err := pfOp.Update(ctx, result.Id, expandApprunPacketFilter(&plan)); err != nil {
+	if _, err := pfOp.Update(ctx, result.ID, expandApprunPacketFilter(&plan)); err != nil {
 		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to update AppRun Shared's packet filter: %s", err))
 		return
 	}
 
 	// 内部的にVersions/Traffics APIを利用してトラフィック分散の状態も変更する
-	versions, err := getVersions(ctx, r.client, result.Id)
+	versions, err := getVersions(ctx, r.client, result.ID)
 	if err != nil {
 		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to get AppRun Shared's versions: %s", err))
 		return
@@ -351,13 +351,13 @@ func (r *apprunSharedResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	_, err = trafficOp.Update(ctx, result.Id, traffics)
+	_, err = trafficOp.Update(ctx, result.ID, traffics)
 	if err != nil {
 		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to update AppRun Shared's traffics: %s", err))
 		return
 	}
 
-	if _, err := updateModel(ctx, &plan, r.client, result.Id); err != nil {
+	if _, err := updateModel(ctx, &plan, r.client, result.ID); err != nil {
 		resp.Diagnostics.AddError("Create: Terraform Error", fmt.Sprintf("failed to update AppRun Shared state: %s", err))
 		return
 	}
@@ -406,20 +406,20 @@ func (r *apprunSharedResource) Update(ctx context.Context, req resource.UpdateRe
 	minScale := int(plan.MinScale.ValueInt32())
 	maxScale := int(plan.MaxScale.ValueInt32())
 	params := v1.PatchApplicationBody{
-		TimeoutSeconds: &timeoutSeconds,
-		Port:           &port,
-		MinScale:       &minScale,
-		MaxScale:       &maxScale,
+		TimeoutSeconds: v1.NewOptInt(timeoutSeconds),
+		Port:           v1.NewOptInt(port),
+		MinScale:       v1.NewOptInt(minScale),
+		MaxScale:       v1.NewOptInt(maxScale),
 		Components:     expandApprunApplicationComponentsForUpdate(&plan, &config),
 	}
-	result, err := appOp.Update(ctx, application.Id, &params)
+	result, err := appOp.Update(ctx, application.ID, &params)
 	if err != nil {
 		resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to update AppRun Shared application: %s", err))
 		return
 	}
 
 	pfOp := apprun.NewPacketFilterOp(r.client)
-	if _, err := pfOp.Update(ctx, result.Id, expandApprunPacketFilter(&plan)); err != nil {
+	if _, err := pfOp.Update(ctx, result.ID, expandApprunPacketFilter(&plan)); err != nil {
 		resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to update AppRun Shared's packet filter: %s", err))
 		return
 	}
@@ -443,7 +443,7 @@ func (r *apprunSharedResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	if removeResource, err := updateModel(ctx, &plan, r.client, result.Id); err != nil {
+	if removeResource, err := updateModel(ctx, &plan, r.client, result.ID); err != nil {
 		if removeResource {
 			resp.State.RemoveResource(ctx)
 		}
@@ -467,14 +467,14 @@ func (r *apprunSharedResource) Delete(ctx context.Context, req resource.DeleteRe
 		return
 	}
 
-	if err := appOp.Delete(ctx, application.Id); err != nil {
+	if err := appOp.Delete(ctx, application.ID); err != nil {
 		resp.Diagnostics.AddError("Delete: API Error", fmt.Sprintf("failed to delete AppRun Shared application: %s", err))
 		return
 	}
 }
 
-func getVersions(ctx context.Context, client *apprun.Client, applicationId string) ([]v1.Version, error) {
-	var versions []v1.Version
+func getVersions(ctx context.Context, client *v1.Client, applicationId string) ([]v1.HandlerListVersionsDataItem, error) {
+	var versions []v1.HandlerListVersionsDataItem
 
 	versionOp := apprun.NewVersionOp(client)
 
@@ -482,8 +482,8 @@ func getVersions(ctx context.Context, client *apprun.Client, applicationId strin
 	pageSize := 100
 	for {
 		vs, err := versionOp.List(ctx, applicationId, &v1.ListApplicationVersionsParams{
-			PageNum:  &pageNum,
-			PageSize: &pageSize,
+			PageNum:  v1.NewOptInt(pageNum),
+			PageSize: v1.NewOptInt(pageSize),
 		})
 		if err != nil {
 			return nil, err
@@ -502,28 +502,22 @@ func getVersions(ctx context.Context, client *apprun.Client, applicationId strin
 // NOTE: AppRunは初回利用時に一度のみユーザーの作成を必要とする。
 // SakuraCloud Providerでは明示的にユーザーの作成を行わず、CURD操作の開始時に暗黙的にユーザーの存在確認と作成を行う。
 // ref. https://manual.sakura.ad.jp/sakura-apprun-api/spec.html#tag/%E3%83%A6%E3%83%BC%E3%82%B8%E3%83%A3
-func createUserIfNotExist(ctx context.Context, client *apprun.Client) error {
+func createUserIfNotExist(ctx context.Context, client *v1.Client) error {
 	userOp := apprun.NewUserOp(client)
-	res, err := userOp.Read(ctx)
-	if err != nil {
-		return err
+	_, err := userOp.Read(ctx)
+
+	if saclient.IsNotFoundError(err) {
+		_, err = userOp.Create(ctx)
 	}
 
-	if res.StatusCode == http.StatusNotFound {
-		_, err := userOp.Create(ctx)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return err
 }
 
-func updateModel(ctx context.Context, model *apprunSharedResourceModel, client *apprun.Client, id string) (bool, error) {
+func updateModel(ctx context.Context, model *apprunSharedResourceModel, client *v1.Client, id string) (bool, error) {
 	appOp := apprun.NewApplicationOp(client)
 	application, err := appOp.Read(ctx, id)
 	if err != nil {
-		if e, ok := err.(*v1.ModelDefaultError); ok && e.Detail.Code == 404 {
+		if saclient.IsNotFoundError(err) {
 			return true, nil
 		}
 		return false, fmt.Errorf("failed to read AppRun Shared application: %s", err)
@@ -541,7 +535,7 @@ func updateModel(ctx context.Context, model *apprunSharedResourceModel, client *
 	}
 
 	pfOp := apprun.NewPacketFilterOp(client)
-	pf, err := pfOp.Read(ctx, application.Id)
+	pf, err := pfOp.Read(ctx, application.ID)
 	if err != nil {
 		return false, fmt.Errorf("failed to read AppRun Shared's packet filter: %s", err)
 	}
@@ -551,48 +545,46 @@ func updateModel(ctx context.Context, model *apprunSharedResourceModel, client *
 	return false, nil
 }
 
-func expandApprunApplicationComponentsForUpdate(model, config *apprunSharedResourceModel) *[]v1.PatchApplicationBodyComponent {
-	var components []v1.PatchApplicationBodyComponent
+func expandApprunApplicationComponentsForUpdate(model, config *apprunSharedResourceModel) []v1.PatchApplicationBodyComponentsItem {
+	var components []v1.PatchApplicationBodyComponentsItem
 	for i, component := range model.Components {
 		cr := component.DeploySource.ContainerRegistry
-		containerRegistry := &v1.PatchApplicationBodyComponentDeploySourceContainerRegistry{
+		containerRegistry := v1.PatchApplicationBodyComponentsItemDeploySourceContainerRegistry{
 			Image: cr.Image.ValueString(),
 		}
 		if !cr.Server.IsNull() && !cr.Server.IsUnknown() {
-			v := cr.Server.ValueString()
-			containerRegistry.Server = &v
+			containerRegistry.Server = v1.NewOptNilString(cr.Server.ValueString())
 		}
 		if !cr.Username.IsNull() && !cr.Username.IsUnknown() {
-			v := cr.Username.ValueString()
-			containerRegistry.Username = &v
+			containerRegistry.Username = v1.NewOptNilString(cr.Username.ValueString())
 		}
 		password := config.Components[i].DeploySource.ContainerRegistry.PasswordWO.ValueString()
 		if password == "" {
 			password = cr.Password.ValueString()
 		}
 		if password != "" {
-			containerRegistry.Password = &password
+			containerRegistry.Password = v1.NewOptNilString(password)
 		}
 
 		envModel := make([]apprunSharedComponentEnvModel, 0, len(component.Env.Elements()))
 		_ = component.Env.ElementsAs(context.Background(), &envModel, false)
-		var env []v1.PatchApplicationBodyComponentEnv
+		var env []v1.PatchApplicationBodyComponentsItemEnvItem
 		for _, e := range envModel {
 			key := e.Key.ValueString()
 			value := e.Value.ValueString()
 
 			env = append(env,
-				v1.PatchApplicationBodyComponentEnv{
-					Key:   &key,
-					Value: &value,
+				v1.PatchApplicationBodyComponentsItemEnvItem{
+					Key:   v1.NewOptString(key),
+					Value: v1.NewOptString(value),
 				})
 		}
 
-		var probe v1.PatchApplicationBodyComponentProbe
+		probe := v1.OptNilPatchApplicationBodyComponentsItemProbe{}
 		if !component.Probe.IsNull() && !component.Probe.IsUnknown() {
 			var d apprunSharedProbeModel
 			_ = component.Probe.As(context.Background(), &d, basetypes.ObjectAsOptions{})
-			probe.HttpGet = &v1.PatchApplicationBodyComponentProbeHttpGet{
+			httpGet := v1.PatchApplicationBodyComponentsItemProbeHTTPGet{
 				Path: d.HttpGet.Path.ValueString(),
 				Port: int(d.HttpGet.Port.ValueInt32()),
 			}
@@ -600,189 +592,184 @@ func expandApprunApplicationComponentsForUpdate(model, config *apprunSharedResou
 			if !d.HttpGet.Headers.IsNull() && !d.HttpGet.Headers.IsUnknown() {
 				headersModel := make([]apprunSharedProbeHttpGetHeaderModel, 0, len(d.HttpGet.Headers.Elements()))
 				_ = d.HttpGet.Headers.ElementsAs(context.Background(), &headersModel, false)
-				var headers []v1.PatchApplicationBodyComponentProbeHttpGetHeader
+				var headers []v1.PatchApplicationBodyComponentsItemProbeHTTPGetHeadersItem
 				for _, h := range headersModel {
 					name := h.Name.ValueString()
 					value := h.Value.ValueString()
 					headers = append(headers,
-						v1.PatchApplicationBodyComponentProbeHttpGetHeader{
-							Name:  &name,
-							Value: &value,
+						v1.PatchApplicationBodyComponentsItemProbeHTTPGetHeadersItem{
+							Name:  v1.NewOptString(name),
+							Value: v1.NewOptString(value),
 						})
 				}
 
-				probe.HttpGet.Headers = &headers
+				httpGet.Headers = headers
 			}
+
+			probe = v1.NewOptNilPatchApplicationBodyComponentsItemProbe(v1.PatchApplicationBodyComponentsItemProbe{
+				HTTPGet: v1.NewOptNilPatchApplicationBodyComponentsItemProbeHTTPGet(httpGet),
+			})
 		}
 
-		components = append(components, v1.PatchApplicationBodyComponent{
+		components = append(components, v1.PatchApplicationBodyComponentsItem{
 			Name:      component.Name.ValueString(),
-			MaxCpu:    v1.PatchApplicationBodyComponentMaxCpu(component.MaxCpu.ValueString()),
-			MaxMemory: v1.PatchApplicationBodyComponentMaxMemory(component.MaxMemory.ValueString()),
-			DeploySource: v1.PatchApplicationBodyComponentDeploySource{
-				ContainerRegistry: containerRegistry,
+			MaxCPU:    v1.PatchApplicationBodyComponentsItemMaxCPU(component.MaxCpu.ValueString()),
+			MaxMemory: v1.PatchApplicationBodyComponentsItemMaxMemory(component.MaxMemory.ValueString()),
+			DeploySource: v1.PatchApplicationBodyComponentsItemDeploySource{
+				ContainerRegistry: v1.NewOptPatchApplicationBodyComponentsItemDeploySourceContainerRegistry(containerRegistry),
 			},
-			Env:   &env,
-			Probe: &probe,
-		})
-	}
-
-	return &components
-}
-
-func expandApprunApplicationComponents(model, config *apprunSharedResourceModel) []v1.PostApplicationBodyComponent {
-	var components []v1.PostApplicationBodyComponent
-	for i, component := range model.Components {
-		cr := component.DeploySource.ContainerRegistry
-		containerRegistry := &v1.PostApplicationBodyComponentDeploySourceContainerRegistry{
-			Image: cr.Image.ValueString(),
-		}
-		if !cr.Server.IsNull() && !cr.Server.IsUnknown() {
-			v := cr.Server.ValueString()
-			containerRegistry.Server = &v
-		}
-		if !cr.Username.IsNull() && !cr.Username.IsUnknown() {
-			v := cr.Username.ValueString()
-			containerRegistry.Username = &v
-		}
-		password := config.Components[i].DeploySource.ContainerRegistry.PasswordWO.ValueString()
-		if password == "" {
-			password = cr.Password.ValueString()
-		}
-		if password != "" {
-			containerRegistry.Password = &password
-		}
-
-		envModel := make([]apprunSharedComponentEnvModel, 0, len(component.Env.Elements()))
-		_ = component.Env.ElementsAs(context.Background(), &envModel, false)
-		var env []v1.PostApplicationBodyComponentEnv
-		for _, e := range envModel {
-			key := e.Key.ValueString()
-			value := e.Value.ValueString()
-
-			env = append(env,
-				v1.PostApplicationBodyComponentEnv{
-					Key:   &key,
-					Value: &value,
-				})
-		}
-
-		var probe v1.PostApplicationBodyComponentProbe
-		if !component.Probe.IsNull() && !component.Probe.IsUnknown() {
-			var d apprunSharedProbeModel
-			_ = component.Probe.As(context.Background(), &d, basetypes.ObjectAsOptions{})
-			probe.HttpGet = &v1.PostApplicationBodyComponentProbeHttpGet{
-				Path: d.HttpGet.Path.ValueString(),
-				Port: int(d.HttpGet.Port.ValueInt32()),
-			}
-
-			if !d.HttpGet.Headers.IsNull() && !d.HttpGet.Headers.IsUnknown() {
-				headersModel := make([]apprunSharedProbeHttpGetHeaderModel, 0, len(d.HttpGet.Headers.Elements()))
-				_ = d.HttpGet.Headers.ElementsAs(context.Background(), &headersModel, false)
-				var headers []v1.PostApplicationBodyComponentProbeHttpGetHeader
-				for _, h := range headersModel {
-					name := h.Name.ValueString()
-					value := h.Value.ValueString()
-					headers = append(headers,
-						v1.PostApplicationBodyComponentProbeHttpGetHeader{
-							Name:  &name,
-							Value: &value,
-						})
-				}
-				probe.HttpGet.Headers = &headers
-			}
-		}
-
-		components = append(components, v1.PostApplicationBodyComponent{
-			Name:      component.Name.ValueString(),
-			MaxCpu:    v1.PostApplicationBodyComponentMaxCpu(component.MaxCpu.ValueString()),
-			MaxMemory: v1.PostApplicationBodyComponentMaxMemory(component.MaxMemory.ValueString()),
-			DeploySource: v1.PostApplicationBodyComponentDeploySource{
-				ContainerRegistry: containerRegistry,
-			},
-			Env:   &env,
-			Probe: &probe,
+			Env:   v1.NewOptNilPatchApplicationBodyComponentsItemEnvItemArray(env),
+			Probe: probe,
 		})
 	}
 
 	return components
 }
 
-func expandApprunApplicationTraffics(model *apprunSharedResourceModel, versions []v1.Version) (*[]v1.Traffic, error) {
-	if len(model.Traffics) == 0 {
-		defaultIsLatestVersion := true
-		defaultPercent := 100
-
-		t := &v1.Traffic{}
-		if err := t.FromTrafficWithLatestVersion(v1.TrafficWithLatestVersion{
-			IsLatestVersion: defaultIsLatestVersion,
-			Percent:         defaultPercent,
-		}); err != nil {
-			return nil, err
+func expandApprunApplicationComponents(model, config *apprunSharedResourceModel) []v1.PostApplicationBodyComponentsItem {
+	var components []v1.PostApplicationBodyComponentsItem
+	for i, component := range model.Components {
+		cr := component.DeploySource.ContainerRegistry
+		containerRegistry := v1.PostApplicationBodyComponentsItemDeploySourceContainerRegistry{
+			Image: cr.Image.ValueString(),
+		}
+		if !cr.Server.IsNull() && !cr.Server.IsUnknown() {
+			containerRegistry.Server = v1.NewOptNilString(cr.Server.ValueString())
+		}
+		if !cr.Username.IsNull() && !cr.Username.IsUnknown() {
+			containerRegistry.Username = v1.NewOptNilString(cr.Username.ValueString())
+		}
+		password := config.Components[i].DeploySource.ContainerRegistry.PasswordWO.ValueString()
+		if password == "" {
+			password = cr.Password.ValueString()
+		}
+		if password != "" {
+			containerRegistry.Password = v1.NewOptNilString(password)
 		}
 
-		return &[]v1.Traffic{*t}, nil
+		envModel := make([]apprunSharedComponentEnvModel, 0, len(component.Env.Elements()))
+		_ = component.Env.ElementsAs(context.Background(), &envModel, false)
+		var env []v1.PostApplicationBodyComponentsItemEnvItem
+		for _, e := range envModel {
+			key := e.Key.ValueString()
+			value := e.Value.ValueString()
+
+			env = append(env,
+				v1.PostApplicationBodyComponentsItemEnvItem{
+					Key:   v1.NewOptString(key),
+					Value: v1.NewOptString(value),
+				})
+		}
+
+		probe := v1.OptNilPostApplicationBodyComponentsItemProbe{}
+		if !component.Probe.IsNull() && !component.Probe.IsUnknown() {
+			var d apprunSharedProbeModel
+			_ = component.Probe.As(context.Background(), &d, basetypes.ObjectAsOptions{})
+			httpGet := v1.PostApplicationBodyComponentsItemProbeHTTPGet{
+				Path: d.HttpGet.Path.ValueString(),
+				Port: int(d.HttpGet.Port.ValueInt32()),
+			}
+
+			if !d.HttpGet.Headers.IsNull() && !d.HttpGet.Headers.IsUnknown() {
+				headersModel := make([]apprunSharedProbeHttpGetHeaderModel, 0, len(d.HttpGet.Headers.Elements()))
+				_ = d.HttpGet.Headers.ElementsAs(context.Background(), &headersModel, false)
+				var headers []v1.PostApplicationBodyComponentsItemProbeHTTPGetHeadersItem
+				for _, h := range headersModel {
+					name := h.Name.ValueString()
+					value := h.Value.ValueString()
+					headers = append(headers,
+						v1.PostApplicationBodyComponentsItemProbeHTTPGetHeadersItem{
+							Name:  v1.NewOptString(name),
+							Value: v1.NewOptString(value),
+						})
+				}
+				httpGet.Headers = headers
+			}
+
+			probe = v1.NewOptNilPostApplicationBodyComponentsItemProbe(v1.PostApplicationBodyComponentsItemProbe{
+				HTTPGet: v1.NewOptNilPostApplicationBodyComponentsItemProbeHTTPGet(httpGet),
+			})
+		}
+
+		components = append(components, v1.PostApplicationBodyComponentsItem{
+			Name:      component.Name.ValueString(),
+			MaxCPU:    v1.PostApplicationBodyComponentsItemMaxCPU(component.MaxCpu.ValueString()),
+			MaxMemory: v1.PostApplicationBodyComponentsItemMaxMemory(component.MaxMemory.ValueString()),
+			DeploySource: v1.PostApplicationBodyComponentsItemDeploySource{
+				ContainerRegistry: v1.NewOptPostApplicationBodyComponentsItemDeploySourceContainerRegistry(containerRegistry),
+			},
+			Env:   v1.NewOptNilPostApplicationBodyComponentsItemEnvItemArray(env),
+			Probe: probe,
+		})
 	}
 
-	var traffics []v1.Traffic
+	return components
+}
+
+func expandApprunApplicationTraffics(model *apprunSharedResourceModel, versions []v1.HandlerListVersionsDataItem) (*v1.PutTrafficsBody, error) {
+	if len(model.Traffics) == 0 {
+		body := v1.PutTrafficsBody{
+			v1.NewPutTrafficsBodyItem0PutTrafficsBodyItem(v1.PutTrafficsBodyItem0{
+				IsLatestVersion: true,
+				Percent:         100,
+			}),
+		}
+		return &body, nil
+	}
+
+	var traffics v1.PutTrafficsBody
 	for _, traffic := range model.Traffics {
 		percent := int(traffic.Percent.ValueInt32())
-		version_index := int(traffic.VersionIndex.ValueInt64())
-		if len(versions) <= version_index {
-			return nil, fmt.Errorf("index out of range, version_index: %d", version_index)
+		versionIndex := int(traffic.VersionIndex.ValueInt64())
+		if len(versions) <= versionIndex {
+			return nil, fmt.Errorf("index out of range, version_index: %d", versionIndex)
 		}
 
-		version := (versions)[version_index]
-		tr := &v1.Traffic{}
-		if err := tr.FromTrafficWithVersionName(v1.TrafficWithVersionName{
+		version := versions[versionIndex]
+		traffics = append(traffics, v1.NewPutTrafficsBodyItem1PutTrafficsBodyItem(v1.PutTrafficsBodyItem1{
 			Percent:     percent,
 			VersionName: version.Name,
-		}); err != nil {
-			return nil, err
-		}
-		traffics = append(traffics, *tr)
+		}))
 	}
 
 	return &traffics, nil
 }
 
 func expandApprunPacketFilter(model *apprunSharedResourceModel) *v1.PatchPacketFilter {
-	enabled := false
 	ret := &v1.PatchPacketFilter{
-		IsEnabled: &enabled,
+		IsEnabled: v1.NewOptBool(false),
 	}
 	if model.PacketFilter != nil {
-		enabled = model.PacketFilter.Enabled.ValueBool()
-		var settings []v1.PacketFilterSetting
+		enabled := model.PacketFilter.Enabled.ValueBool()
+		var settings []v1.PatchPacketFilterSettingsItem
 		for _, setting := range model.PacketFilter.Settings {
-			settings = append(settings, v1.PacketFilterSetting{
-				FromIp:             setting.FromIP.ValueString(),
-				FromIpPrefixLength: int(setting.FromIPPrefixLength.ValueInt32()),
+			settings = append(settings, v1.PatchPacketFilterSettingsItem{
+				FromIP:             setting.FromIP.ValueString(),
+				FromIPPrefixLength: int(setting.FromIPPrefixLength.ValueInt32()),
 			})
 		}
 
-		ret.IsEnabled = &enabled
-		ret.Settings = &settings
+		ret.IsEnabled = v1.NewOptBool(enabled)
+		ret.Settings = settings
 	}
 	return ret
 }
 
-func flattenApprunApplicationTraffics(traffics []v1.Traffic, versions []v1.Version) []apprunSharedTrafficsModel {
+func flattenApprunApplicationTraffics(traffics []v1.HandlerListTrafficsDataItem, versions []v1.HandlerListVersionsDataItem) []apprunSharedTrafficsModel {
 	if len(traffics) == 0 {
 		return nil
 	}
 
 	var results []apprunSharedTrafficsModel
 	for _, traffic := range traffics {
-		withVersion, err := traffic.AsTrafficWithVersionName()
-		if err != nil {
+		if traffic.VersionName == "" {
 			continue
 		}
 		for i, version := range versions {
-			if withVersion.VersionName == version.Name {
+			if traffic.VersionName == version.Name {
 				results = append(results, apprunSharedTrafficsModel{
 					VersionIndex: types.Int64Value(int64(i)),
-					Percent:      types.Int32Value(int32(withVersion.Percent)),
+					Percent:      types.Int32Value(int32(traffic.Percent)),
 				})
 				continue
 			}

--- a/internal/service/apprun_shared/resource.go
+++ b/internal/service/apprun_shared/resource.go
@@ -580,6 +580,10 @@ func expandApprunApplicationComponentsForUpdate(model, config *apprunSharedResou
 				})
 		}
 
+		if env == nil {
+			env = make([]v1.PatchApplicationBodyComponentsItemEnvItem, 0)
+		}
+
 		probe := v1.OptNilPatchApplicationBodyComponentsItemProbe{}
 		if !component.Probe.IsNull() && !component.Probe.IsUnknown() {
 			var d apprunSharedProbeModel
@@ -659,6 +663,10 @@ func expandApprunApplicationComponents(model, config *apprunSharedResourceModel)
 					Key:   v1.NewOptString(key),
 					Value: v1.NewOptString(value),
 				})
+		}
+
+		if env == nil {
+			env = make([]v1.PostApplicationBodyComponentsItemEnvItem, 0)
 		}
 
 		probe := v1.OptNilPostApplicationBodyComponentsItemProbe{}

--- a/internal/service/apprun_shared/resource_test.go
+++ b/internal/service/apprun_shared/resource_test.go
@@ -21,7 +21,7 @@ func TestAccSakuraApprunShared_basic(t *testing.T) {
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
 
-	var application v1.Application
+	var application v1.HandlerGetApplication
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
@@ -71,7 +71,7 @@ func TestAccSakuraApprunShared_withCRUser(t *testing.T) {
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
 
-	var application v1.Application
+	var application v1.HandlerGetApplication
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
@@ -106,7 +106,7 @@ func TestAccSakuraApprunShared_withCRUserWithWO(t *testing.T) {
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
 
-	var application v1.Application
+	var application v1.HandlerGetApplication
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
@@ -141,7 +141,7 @@ func TestAccSakuraApprunShared_withEnv(t *testing.T) {
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
 
-	var application v1.Application
+	var application v1.HandlerGetApplication
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
@@ -176,7 +176,7 @@ func TestAccSakuraApprunShared_withEnvUpdate(t *testing.T) {
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
 
-	var application v1.Application
+	var application v1.HandlerGetApplication
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
@@ -218,7 +218,7 @@ func TestAccSakuraApprunShared_withProbe(t *testing.T) {
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
 
-	var application v1.Application
+	var application v1.HandlerGetApplication
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
@@ -272,7 +272,7 @@ func TestAccSakuraApprunShared_withTraffic(t *testing.T) {
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
 
-	var application v1.Application
+	var application v1.HandlerGetApplication
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
@@ -515,7 +515,7 @@ func TestAccImportSakuraApprunShared_withEnv(t *testing.T) {
 	})
 }
 
-func testCheckSakuraApprunSharedExists(n string, application *v1.Application) resource.TestCheckFunc {
+func testCheckSakuraApprunSharedExists(n string, application *v1.HandlerGetApplication) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -535,7 +535,7 @@ func testCheckSakuraApprunSharedExists(n string, application *v1.Application) re
 			return err
 		}
 
-		if found.Id != rs.Primary.ID {
+		if found.ID != rs.Primary.ID {
 			return fmt.Errorf("not found AppRun Application: %s", rs.Primary.ID)
 		}
 
@@ -544,14 +544,14 @@ func testCheckSakuraApprunSharedExists(n string, application *v1.Application) re
 	}
 }
 
-func testCheckSakuraApprunSharedAttributes(application *v1.Application) resource.TestCheckFunc {
+func testCheckSakuraApprunSharedAttributes(application *v1.HandlerGetApplication) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if len(application.Components) == 0 {
 			return errors.New("unexpected application components: components is nil")
 		}
 
 		c := (application.Components)[0]
-		if c.DeploySource.ContainerRegistry == nil {
+		if _, ok := c.DeploySource.ContainerRegistry.Get(); !ok {
 			return errors.New("unexpected application components: container_registry is nil")
 		}
 


### PR DESCRIPTION
依存しているapprun-api-goのバージョンアップです

基本的に従来と同じですが、型名が変わるなどの非互換のある部分を置換しています。