### PR TITLE
Update apprun_shared test

### DIFF
--- a/docs/resources/apprun_shared.md
+++ b/docs/resources/apprun_shared.md
@@ -25,7 +25,7 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "256Mi"
     deploy_source = {
       container_registry = {
-        image    = "foobar.sakuracr.jp/my-app:latest" // or duckerhub / ghcr.io
+        image    = "foobar.sakuracr.jp/my-app:latest" // or dockerhub / ghcr.io
         server   = "foobar.sakuracr.jp"
         username = "username"
         password_wo = "userpassword"

--- a/docs/resources/apprun_shared.md
+++ b/docs/resources/apprun_shared.md
@@ -25,11 +25,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "256Mi"
     deploy_source = {
       container_registry = {
-        image    = "foobar.sakuracr.jp/my-app:latest"
-        //server   = "foobar.sakuracr.jp"
-        //username = "username"
-        //password_wo = "userpassword"
-        //password_wo_version = 1
+        image    = "foobar.sakuracr.jp/my-app:latest" // or duckerhub / ghcr.io
+        server   = "foobar.sakuracr.jp"
+        username = "username"
+        password_wo = "userpassword"
+        password_wo_version = 1
         // for backward compatibility
         //password = "userpassword"
       }

--- a/examples/resources/sakura_apprun_shared/resource.tf
+++ b/examples/resources/sakura_apprun_shared/resource.tf
@@ -10,11 +10,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "256Mi"
     deploy_source = {
       container_registry = {
-        image    = "foobar.sakuracr.jp/my-app:latest"
-        //server   = "foobar.sakuracr.jp"
-        //username = "username"
-        //password_wo = "userpassword"
-        //password_wo_version = 1
+        image    = "foobar.sakuracr.jp/my-app:latest" // or duckerhub / ghcr.io
+        server   = "foobar.sakuracr.jp"
+        username = "username"
+        password_wo = "userpassword"
+        password_wo_version = 1
         // for backward compatibility
         //password = "userpassword"
       }

--- a/examples/resources/sakura_apprun_shared/resource.tf
+++ b/examples/resources/sakura_apprun_shared/resource.tf
@@ -10,7 +10,7 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "256Mi"
     deploy_source = {
       container_registry = {
-        image    = "foobar.sakuracr.jp/my-app:latest" // or duckerhub / ghcr.io
+        image    = "foobar.sakuracr.jp/my-app:latest" // or dockerhub / ghcr.io
         server   = "foobar.sakuracr.jp"
         username = "username"
         password_wo = "userpassword"

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/sacloud/addon-api-go v0.1.0
 	github.com/sacloud/api-client-go v0.3.5
 	github.com/sacloud/apigw-api-go v0.3.0
-	github.com/sacloud/apprun-api-go v0.8.0
+	github.com/sacloud/apprun-api-go v0.8.1
 	github.com/sacloud/apprun-dedicated-api-go v0.2.0
 	github.com/sacloud/autoscaler v0.19.3
 	github.com/sacloud/cloudhsm-api-go v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/sacloud/api-client-go v0.3.5 h1:0ALibvbC+6MBhN7t61k+RhguhiEQ8+NejqBjq
 github.com/sacloud/api-client-go v0.3.5/go.mod h1:akdcCOl6wszywa0YQ5X8cMnNgWTm+7N4EneODTdiH48=
 github.com/sacloud/apigw-api-go v0.3.0 h1:dxrV2L6/SNdRM0dLJm+p9d40bOWopVYmykD8TAJL1qY=
 github.com/sacloud/apigw-api-go v0.3.0/go.mod h1:YtaZ7lYtjwI4PrnrVvYStQEjrb2lTbyac/L95giqApg=
-github.com/sacloud/apprun-api-go v0.8.0 h1:VT64rGY9gV9fkWiq4On4/zlp6LO8RGEL9EtdLOzXMyc=
-github.com/sacloud/apprun-api-go v0.8.0/go.mod h1:rqwzv6jKBzRNwL29jD8oFVdLoiFy9WgFzrInOR1iO9c=
+github.com/sacloud/apprun-api-go v0.8.1 h1:2GReC3uY/qutgrDnZYL3PV1jNlCJiIU1Wfph0JfrM2k=
+github.com/sacloud/apprun-api-go v0.8.1/go.mod h1:rqwzv6jKBzRNwL29jD8oFVdLoiFy9WgFzrInOR1iO9c=
 github.com/sacloud/apprun-dedicated-api-go v0.2.0 h1:UUHDclY5Po8V7HuSzKwHdzVCkCD7VkNVoD2f+2O1Ptc=
 github.com/sacloud/apprun-dedicated-api-go v0.2.0/go.mod h1:znwpgRva+AKZ2lrBN7F+2jlWhqfLqEt4ZNQp6LbZ9vA=
 github.com/sacloud/autoscaler v0.19.3 h1:FkBxc0mE8fvaWiOiz+TpFAT1TX8DRLXs8prsqaM2MF0=
@@ -409,6 +409,7 @@ golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
+gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM=
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=

--- a/internal/service/apprun_shared/data_source_test.go
+++ b/internal/service/apprun_shared/data_source_test.go
@@ -4,6 +4,7 @@
 package apprun_shared_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -11,15 +12,18 @@ import (
 )
 
 func TestAccSakuraDataSourceApprunShared_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
+
 	resourceName := "data.sakura_apprun_shared.foobar"
 	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraDataSourceApprunShared_basic, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraDataSourceApprunShared_basic, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					test.CheckSakuraDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
@@ -31,6 +35,7 @@ func TestAccSakuraDataSourceApprunShared_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.username", "test-user"),
 					resource.TestCheckResourceAttrSet(resourceName, "resource_id"),
 				),
 			},
@@ -38,7 +43,7 @@ func TestAccSakuraDataSourceApprunShared_basic(t *testing.T) {
 	})
 }
 
-func TestAccSakuraDataSourceApprunShared_withCRUser(t *testing.T) {
+func TestAccSakuraDataSourceApprunShared_externalRegistry(t *testing.T) {
 	resourceName := "data.sakura_apprun_shared.foobar"
 	rand := test.RandomName()
 
@@ -47,7 +52,7 @@ func TestAccSakuraDataSourceApprunShared_withCRUser(t *testing.T) {
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraDataSourceApprunShared_withCRUser, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraDataSourceApprunShared_externalRegistry, rand),
 				Check: resource.ComposeTestCheckFunc(
 					test.CheckSakuraDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
@@ -58,9 +63,7 @@ func TestAccSakuraDataSourceApprunShared_withCRUser(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.server", "sakura-oss-dev.sakuracr.jp"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.username", "user"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.image", "ghcr.io/nginx/nginx-gateway-fabric/nginx:2.6.2"),
 				),
 			},
 		},
@@ -68,15 +71,18 @@ func TestAccSakuraDataSourceApprunShared_withCRUser(t *testing.T) {
 }
 
 func TestAccSakuraDataSourceApprunShared_withProbe(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
+
 	resourceName := "data.sakura_apprun_shared.foobar"
 	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraDataSourceApprunShared_withProbe, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraDataSourceApprunShared_withProbe, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					test.CheckSakuraDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
@@ -101,16 +107,19 @@ func TestAccSakuraDataSourceApprunShared_withProbe(t *testing.T) {
 }
 
 func TestAccSakuraDataSourceApprunShared_withTraffic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
+
 	// Use resource to check traffics setting
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraDataSourceApprunShared_withTraffic, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraDataSourceApprunShared_withTraffic, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					test.CheckSakuraDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
@@ -131,15 +140,18 @@ func TestAccSakuraDataSourceApprunShared_withTraffic(t *testing.T) {
 }
 
 func TestAccSakuraDataSourceApprunShared_withPacketFilter(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
+
 	resourceName := "data.sakura_apprun_shared.foobar"
 	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraDataSourceApprunShared_withPacketFilter, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraDataSourceApprunShared_withPacketFilter, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					test.CheckSakuraDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
@@ -166,7 +178,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
   }]
@@ -181,7 +197,7 @@ data "sakura_apprun_shared" "foobar" {
 }
 `
 
-var testAccSakuraDataSourceApprunShared_withCRUser = `
+var testAccSakuraDataSourceApprunShared_externalRegistry = `
 resource "sakura_apprun_shared" "foobar" {
   name            = "{{ .arg0 }}"
   timeout_seconds = 90
@@ -194,10 +210,7 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
-        server   = "sakura-oss-dev.sakuracr.jp"
-        username = "user"
-        password = "password"
+        image = "ghcr.io/nginx/nginx-gateway-fabric/nginx:2.6.2"
       }
     }
   }]
@@ -221,7 +234,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
     probe = {
@@ -259,7 +276,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
   }]
@@ -287,7 +308,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
   }]

--- a/internal/service/apprun_shared/resource_test.go
+++ b/internal/service/apprun_shared/resource_test.go
@@ -633,6 +633,7 @@ resource "sakura_apprun_shared" "foobar" {
 }
 `
 
+//nolint:gosec
 const testAccSakuraApprunShared_withOldPassword = `
 resource "sakura_apprun_shared" "foobar" {
   name            = "{{ .arg0 }}"

--- a/internal/service/apprun_shared/resource_test.go
+++ b/internal/service/apprun_shared/resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -18,8 +19,11 @@ import (
 )
 
 func TestAccSakuraApprunShared_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
+
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 
 	var application v1.HandlerGetApplication
 	resource.Test(t, resource.TestCase{
@@ -28,7 +32,7 @@ func TestAccSakuraApprunShared_basic(t *testing.T) {
 		CheckDestroy:             testCheckSakuraApprunSharedDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_basic, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_basic, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraApprunSharedExists(resourceName, &application),
 					testCheckSakuraApprunSharedAttributes(&application),
@@ -41,13 +45,16 @@ func TestAccSakuraApprunShared_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.server", "sakura-oss-dev.sakuracr.jp"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.username", "test-user"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.password_wo_version", "1"),
 					resource.TestMatchResourceAttr(resourceName, "status", regexp.MustCompile(".+")),
 					resource.TestMatchResourceAttr(resourceName, "public_url", regexp.MustCompile(".+")),
 					resource.TestCheckResourceAttrSet(resourceName, "resource_id"),
 				),
 			},
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_update, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_update, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraApprunSharedExists(resourceName, &application),
 					testCheckSakuraApprunSharedAttributes(&application),
@@ -60,6 +67,9 @@ func TestAccSakuraApprunShared_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "1"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "2Gi"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.image", "sakura-oss-dev.sakuracr.jp/test:tag1"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.server", "sakura-oss-dev.sakuracr.jp"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.username", "test-user"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.password_wo_version", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "resource_id"),
 				),
 			},
@@ -67,7 +77,7 @@ func TestAccSakuraApprunShared_basic(t *testing.T) {
 	})
 }
 
-func TestAccSakuraApprunShared_withCRUser(t *testing.T) {
+func TestAccSakuraApprunShared_externalRegistry(t *testing.T) {
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
 
@@ -78,7 +88,40 @@ func TestAccSakuraApprunShared_withCRUser(t *testing.T) {
 		CheckDestroy:             testCheckSakuraApprunSharedDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withCRUser, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_externalRegistry, rand),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraApprunSharedExists(resourceName, &application),
+					testCheckSakuraApprunSharedAttributes(&application),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "timeout_seconds", "90"),
+					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "min_scale", "0"),
+					resource.TestCheckResourceAttr(resourceName, "max_scale", "1"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.image", "ghcr.io/nginx/nginx-gateway-fabric/nginx:2.6.2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSakuraApprunShared_withOldPassword(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
+
+	resourceName := "sakura_apprun_shared.foobar"
+	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
+
+	var application v1.HandlerGetApplication
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraApprunSharedDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withOldPassword, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraApprunSharedExists(resourceName, &application),
 					testCheckSakuraApprunSharedAttributes(&application),
@@ -92,8 +135,8 @@ func TestAccSakuraApprunShared_withCRUser(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
 					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.server", "sakura-oss-dev.sakuracr.jp"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.username", "user"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.password", "password"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.username", "test-user"),
+					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.password", pass),
 					resource.TestCheckNoResourceAttr(resourceName, "components.0.deploy_source.container_registry.password_wo"),
 					resource.TestCheckNoResourceAttr(resourceName, "components.0.deploy_source.container_registry.password_wo_version"),
 				),
@@ -102,44 +145,12 @@ func TestAccSakuraApprunShared_withCRUser(t *testing.T) {
 	})
 }
 
-func TestAccSakuraApprunShared_withCRUserWithWO(t *testing.T) {
-	resourceName := "sakura_apprun_shared.foobar"
-	rand := test.RandomName()
-
-	var application v1.HandlerGetApplication
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { test.AccPreCheck(t) },
-		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
-		CheckDestroy:             testCheckSakuraApprunSharedDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withCRUserWithWO, rand),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckSakuraApprunSharedExists(resourceName, &application),
-					testCheckSakuraApprunSharedAttributes(&application),
-					resource.TestCheckResourceAttr(resourceName, "name", rand),
-					resource.TestCheckResourceAttr(resourceName, "timeout_seconds", "90"),
-					resource.TestCheckResourceAttr(resourceName, "port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "min_scale", "0"),
-					resource.TestCheckResourceAttr(resourceName, "max_scale", "1"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.name", "compo1"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.max_cpu", "0.5"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.max_memory", "1Gi"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.image", "sakura-oss-dev.sakuracr.jp/test:latest"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.server", "sakura-oss-dev.sakuracr.jp"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.username", "user"),
-					resource.TestCheckNoResourceAttr(resourceName, "components.0.deploy_source.container_registry.password"),
-					resource.TestCheckNoResourceAttr(resourceName, "components.0.deploy_source.container_registry.password_wo"),
-					resource.TestCheckResourceAttr(resourceName, "components.0.deploy_source.container_registry.password_wo_version", "1"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccSakuraApprunShared_withEnv(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
+
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 
 	var application v1.HandlerGetApplication
 	resource.Test(t, resource.TestCase{
@@ -148,7 +159,7 @@ func TestAccSakuraApprunShared_withEnv(t *testing.T) {
 		CheckDestroy:             testCheckSakuraApprunSharedDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withEnv, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withEnv, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraApprunSharedExists(resourceName, &application),
 					testCheckSakuraApprunSharedAttributes(&application),
@@ -173,8 +184,11 @@ func TestAccSakuraApprunShared_withEnv(t *testing.T) {
 }
 
 func TestAccSakuraApprunShared_withEnvUpdate(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
+
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 
 	var application v1.HandlerGetApplication
 	resource.Test(t, resource.TestCase{
@@ -183,7 +197,7 @@ func TestAccSakuraApprunShared_withEnvUpdate(t *testing.T) {
 		CheckDestroy:             testCheckSakuraApprunSharedDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withEnv, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withEnv, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraApprunSharedExists(resourceName, &application),
 					testCheckSakuraApprunSharedAttributes(&application),
@@ -196,7 +210,7 @@ func TestAccSakuraApprunShared_withEnvUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withEnvUpdate, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withEnvUpdate, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraApprunSharedExists(resourceName, &application),
 					testCheckSakuraApprunSharedAttributes(&application),
@@ -215,8 +229,11 @@ func TestAccSakuraApprunShared_withEnvUpdate(t *testing.T) {
 }
 
 func TestAccSakuraApprunShared_withProbe(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
+
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 
 	var application v1.HandlerGetApplication
 	resource.Test(t, resource.TestCase{
@@ -225,7 +242,7 @@ func TestAccSakuraApprunShared_withProbe(t *testing.T) {
 		CheckDestroy:             testCheckSakuraApprunSharedDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withProbe, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withProbe, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraApprunSharedExists(resourceName, &application),
 					testCheckSakuraApprunSharedAttributes(&application),
@@ -243,7 +260,7 @@ func TestAccSakuraApprunShared_withProbe(t *testing.T) {
 				),
 			},
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withProbeUpdate, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withProbeUpdate, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraApprunSharedExists(resourceName, &application),
 					testCheckSakuraApprunSharedAttributes(&application),
@@ -269,8 +286,11 @@ func TestAccSakuraApprunShared_withProbe(t *testing.T) {
 }
 
 func TestAccSakuraApprunShared_withTraffic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
+
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 
 	var application v1.HandlerGetApplication
 	resource.Test(t, resource.TestCase{
@@ -279,7 +299,7 @@ func TestAccSakuraApprunShared_withTraffic(t *testing.T) {
 		CheckDestroy:             testCheckSakuraApprunSharedDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withTraffic, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withTraffic, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraApprunSharedExists(resourceName, &application),
 					testCheckSakuraApprunSharedAttributes(&application),
@@ -297,7 +317,7 @@ func TestAccSakuraApprunShared_withTraffic(t *testing.T) {
 				),
 			},
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withTrafficUpdate, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withTrafficUpdate, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraApprunSharedExists(resourceName, &application),
 					testCheckSakuraApprunSharedAttributes(&application),
@@ -321,15 +341,18 @@ func TestAccSakuraApprunShared_withTraffic(t *testing.T) {
 }
 
 func TestAccSakuraApprunShared_withPacketFilter(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
+
 	resourceName := "sakura_apprun_shared.foobar"
 	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withPacketFilter, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withPacketFilter, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					test.CheckSakuraDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
@@ -340,7 +363,7 @@ func TestAccSakuraApprunShared_withPacketFilter(t *testing.T) {
 				),
 			},
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withPacketFilterUpdate, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withPacketFilterUpdate, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					test.CheckSakuraDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
@@ -353,7 +376,7 @@ func TestAccSakuraApprunShared_withPacketFilter(t *testing.T) {
 				),
 			},
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withPacketFilterDisabled, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withPacketFilterDisabled, rand, pass),
 				Check: resource.ComposeTestCheckFunc(
 					test.CheckSakuraDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
@@ -370,53 +393,9 @@ func TestAccSakuraApprunShared_withPacketFilter(t *testing.T) {
 }
 
 func TestAccImportSakuraApprunShared_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 	rand := test.RandomName()
-	checkFn := func(s []*terraform.InstanceState) error {
-		if len(s) != 1 {
-			return fmt.Errorf("expected 1 state: %#v", s)
-		}
-		expects := map[string]string{
-			"name":                    rand,
-			"timeout_seconds":         "90",
-			"port":                    "80",
-			"min_scale":               "0",
-			"max_scale":               "1",
-			"components.0.name":       "compo1",
-			"components.0.max_cpu":    "0.5",
-			"components.0.max_memory": "1Gi",
-			"components.0.deploy_source.container_registry.image": "sakura-oss-dev.sakuracr.jp/test:latest",
-		}
-
-		return test.CompareStateMulti(s[0], expects)
-	}
-
-	resourceName := "sakura_apprun_shared.foobar"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { test.AccPreCheck(t) },
-		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
-		CheckDestroy:             testCheckSakuraApprunSharedDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_basic, rand),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateCheck:  checkFn,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"status",
-					"resource_id",
-					"public_url",
-				},
-			},
-		},
-	})
-}
-
-func TestAccImportSakuraApprunShared_withCRUser(t *testing.T) {
-	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 	checkFn := func(s []*terraform.InstanceState) error {
 		if len(s) != 1 {
 			return fmt.Errorf("expected 1 state: %#v", s)
@@ -431,7 +410,8 @@ func TestAccImportSakuraApprunShared_withCRUser(t *testing.T) {
 			"components.0.max_cpu":    "0.5",
 			"components.0.max_memory": "1Gi",
 			"components.0.deploy_source.container_registry.image":    "sakura-oss-dev.sakuracr.jp/test:latest",
-			"components.0.deploy_source.container_registry.username": "user",
+			"components.0.deploy_source.container_registry.server":   "sakura-oss-dev.sakuracr.jp",
+			"components.0.deploy_source.container_registry.username": "test-user",
 			"components.0.deploy_source.container_registry.password": "",
 		}
 
@@ -446,7 +426,7 @@ func TestAccImportSakuraApprunShared_withCRUser(t *testing.T) {
 		CheckDestroy:             testCheckSakuraApprunSharedDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withCRUser, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_basic, rand, pass),
 			},
 			{
 				ResourceName:      resourceName,
@@ -454,10 +434,10 @@ func TestAccImportSakuraApprunShared_withCRUser(t *testing.T) {
 				ImportStateCheck:  checkFn,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"components.0.deploy_source.container_registry.password",
 					"status",
 					"resource_id",
 					"public_url",
+					"components.0.deploy_source.container_registry.password_wo_version",
 				},
 			},
 		},
@@ -465,7 +445,9 @@ func TestAccImportSakuraApprunShared_withCRUser(t *testing.T) {
 }
 
 func TestAccImportSakuraApprunShared_withEnv(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 	rand := test.RandomName()
+	pass := os.Getenv("SAKURA_CONTAINER_REGISTRY_USER_PASSWORD")
 	checkFn := func(s []*terraform.InstanceState) error {
 		if len(s) != 1 {
 			return fmt.Errorf("expected 1 state: %#v", s)
@@ -479,7 +461,9 @@ func TestAccImportSakuraApprunShared_withEnv(t *testing.T) {
 			"components.0.name":       "compo1",
 			"components.0.max_cpu":    "0.5",
 			"components.0.max_memory": "1Gi",
-			"components.0.deploy_source.container_registry.image": "sakura-oss-dev.sakuracr.jp/test:latest",
+			"components.0.deploy_source.container_registry.image":    "sakura-oss-dev.sakuracr.jp/test:latest",
+			"components.0.deploy_source.container_registry.username": "test-user",
+			"components.0.deploy_source.container_registry.password": "",
 			"components.0.env.#":       "2",
 			"components.0.env.0.key":   "key",
 			"components.0.env.0.value": "value",
@@ -498,7 +482,7 @@ func TestAccImportSakuraApprunShared_withEnv(t *testing.T) {
 		CheckDestroy:             testCheckSakuraApprunSharedDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withEnv, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraApprunShared_withEnv, rand, pass),
 			},
 			{
 				ResourceName:      resourceName,
@@ -509,6 +493,7 @@ func TestAccImportSakuraApprunShared_withEnv(t *testing.T) {
 					"status",
 					"resource_id",
 					"public_url",
+					"components.0.deploy_source.container_registry.password_wo_version",
 				},
 			},
 		},
@@ -593,7 +578,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
   }]
@@ -613,14 +602,38 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "2Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:tag1"
+        image    = "sakura-oss-dev.sakuracr.jp/test:tag1"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
+      }
+    }
+  }]
+}`
+
+// docker hubはrate limitが厳しいため、外部レジストリのテストにはghcr.ioを利用する
+const testAccSakuraApprunShared_externalRegistry = `
+resource "sakura_apprun_shared" "foobar" {
+  name            = "{{ .arg0 }}"
+  timeout_seconds = 90
+  port            = 80
+  min_scale       = 0
+  max_scale       = 1
+  components = [{
+    name       = "compo1"
+    max_cpu    = "0.5"
+    max_memory = "1Gi"
+    deploy_source = {
+      container_registry = {
+        image = "ghcr.io/nginx/nginx-gateway-fabric/nginx:2.6.2"
       }
     }
   }]
 }
 `
 
-const testAccSakuraApprunShared_withCRUser = `
+const testAccSakuraApprunShared_withOldPassword = `
 resource "sakura_apprun_shared" "foobar" {
   name            = "{{ .arg0 }}"
   timeout_seconds = 90
@@ -635,32 +648,8 @@ resource "sakura_apprun_shared" "foobar" {
       container_registry = {
         image    = "sakura-oss-dev.sakuracr.jp/test:latest"
         server   = "sakura-oss-dev.sakuracr.jp"
-        username = "user"
-        password = "password"
-      }
-    }
-  }]
-}
-`
-
-const testAccSakuraApprunShared_withCRUserWithWO = `
-resource "sakura_apprun_shared" "foobar" {
-  name            = "{{ .arg0 }}"
-  timeout_seconds = 90
-  port            = 80
-  min_scale       = 0
-  max_scale       = 1
-  components = [{
-    name       = "compo1"
-    max_cpu    = "0.5"
-    max_memory = "1Gi"
-    deploy_source = {
-      container_registry = {
-        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
-        server   = "sakura-oss-dev.sakuracr.jp"
-        username = "user"
-        password_wo = "password"
-		password_wo_version = 1
+        username = "test-user"
+        password = "{{ .arg1 }}"
       }
     }
   }]
@@ -680,7 +669,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
     env = [{
@@ -712,7 +705,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
 	// Updated
@@ -747,7 +744,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
     probe = {
@@ -773,7 +774,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image   = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
     probe = {
@@ -807,7 +812,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
   }]
@@ -831,7 +840,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
   }]
@@ -859,7 +872,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
   }]
@@ -886,7 +903,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
   }]
@@ -917,7 +938,11 @@ resource "sakura_apprun_shared" "foobar" {
     max_memory = "1Gi"
     deploy_source = {
       container_registry = {
-        image = "sakura-oss-dev.sakuracr.jp/test:latest"
+        image    = "sakura-oss-dev.sakuracr.jp/test:latest"
+        server   = "sakura-oss-dev.sakuracr.jp"
+        username = "test-user"
+        password_wo = "{{ .arg1 }}"
+        password_wo_version = 1
       }
     }
   }]


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

https://cloud.sakura.ad.jp/news/2026/05/27/container-registry-public-access-setting-discontinued/

上記対応のためコンテナレジストリの利用にusername/password_woをテストで指定。
また外部レジストリが利用できるようになったのでghcrのテストも追加。
今後は環境変数として `SAKURA_CONTAINER_REGISTRY_USER_PASSWORD` が必要となります。

```
=== RUN   TestAccSakuraDataSourceApprunShared_basic
--- PASS: TestAccSakuraDataSourceApprunShared_basic (11.86s)
=== RUN   TestAccSakuraDataSourceApprunShared_externalRegistry
--- PASS: TestAccSakuraDataSourceApprunShared_externalRegistry (11.46s)
=== RUN   TestAccSakuraDataSourceApprunShared_withProbe
--- PASS: TestAccSakuraDataSourceApprunShared_withProbe (12.18s)
=== RUN   TestAccSakuraDataSourceApprunShared_withTraffic
--- PASS: TestAccSakuraDataSourceApprunShared_withTraffic (14.41s)
=== RUN   TestAccSakuraDataSourceApprunShared_withPacketFilter
--- PASS: TestAccSakuraDataSourceApprunShared_withPacketFilter (13.93s)
=== RUN   TestAccSakuraApprunShared_basic
--- PASS: TestAccSakuraApprunShared_basic (19.50s)
=== RUN   TestAccSakuraApprunShared_externalRegistry
--- PASS: TestAccSakuraApprunShared_externalRegistry (15.69s)
=== RUN   TestAccSakuraApprunShared_withOldPassword
--- PASS: TestAccSakuraApprunShared_withOldPassword (9.93s)
=== RUN   TestAccSakuraApprunShared_withEnv
--- PASS: TestAccSakuraApprunShared_withEnv (9.98s)
=== RUN   TestAccSakuraApprunShared_withEnvUpdate
--- PASS: TestAccSakuraApprunShared_withEnvUpdate (17.81s)
=== RUN   TestAccSakuraApprunShared_withProbe
--- PASS: TestAccSakuraApprunShared_withProbe (20.57s)
=== RUN   TestAccSakuraApprunShared_withTraffic
--- PASS: TestAccSakuraApprunShared_withTraffic (19.75s)
=== RUN   TestAccSakuraApprunShared_withPacketFilter
--- PASS: TestAccSakuraApprunShared_withPacketFilter (25.87s)
=== RUN   TestAccImportSakuraApprunShared_basic
--- PASS: TestAccImportSakuraApprunShared_basic (11.79s)
=== RUN   TestAccImportSakuraApprunShared_withEnv
--- PASS: TestAccImportSakuraApprunShared_withEnv (11.54s)
PASS
ok  	github.com/sacloud/terraform-provider-sakura/internal/service/apprun_shared	227.005s
```

### ドキュメントの変更は必要ですか？

例からusername/password_wo/password_wo_versionのコメントアウトを削除して指定するをデフォルトに。