### PR TITLE
Fix KMS resource

### DIFF
--- a/internal/service/kms/resource.go
+++ b/internal/service/kms/resource.go
@@ -25,6 +25,7 @@ import (
 	v1 "github.com/sacloud/kms-api-go/apis/v1"
 	"github.com/sacloud/saclient-go"
 	"github.com/sacloud/terraform-provider-sakura/internal/common"
+	"github.com/sacloud/terraform-provider-sakura/internal/common/utils"
 )
 
 type kmsResource struct {
@@ -318,9 +319,10 @@ func expandKMSUpdateKey(model *kmsResourceModel, before *v1.Key) v1.Key {
 		Description: model.Description.ValueString(),
 		KeyOrigin:   before.KeyOrigin,
 	}
-
-	if !model.Tags.IsNull() {
+	if utils.IsKnown(model.Tags) {
 		req.Tags = common.TsetToStrings(model.Tags)
+	} else {
+		req.Tags = []string{}
 	}
 
 	return req

--- a/internal/service/kms/resource.go
+++ b/internal/service/kms/resource.go
@@ -116,7 +116,7 @@ func (r *kmsResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp
 				Optional:    true,
 				Computed:    true,
 				Default:     int64default.StaticInt64(0),
-				Description: "The rotateion version. This number is incremented when you want rotate KMS key.",
+				Description: "The rotation version. This number is incremented when you want rotate KMS key.",
 			},
 			"latest_version": schema.Int64Attribute{
 				Computed:    true,
@@ -194,6 +194,10 @@ func (r *kmsResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	}
 
 	data.updateState(key)
+	// set default value to avoid unknown value in plan after import
+	if !utils.IsKnown(data.RotateVersion) {
+		data.RotateVersion = types.Int64Value(0)
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/service/kms/resource_test.go
+++ b/internal/service/kms/resource_test.go
@@ -126,6 +126,38 @@ func TestAccSakuraResourceKMS_importedWithWO(t *testing.T) {
 	})
 }
 
+// OpenAPI定義の更新によってUpdate時のtagsが必須になったことに対するテスト
+func TestAccSakuraResourceKMS_tagsIssue(t *testing.T) {
+	resourceName := "sakura_kms.foobar"
+	rand := test.RandomName()
+	var key v1.Key
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraKMSDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraKMS_tagsIssue, rand),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraKMSExists(resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "description", "description"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
+				),
+			},
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraKMS_tagsIssueUpdate, rand),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraKMSExists(resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "description", "description-updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckSakuraKMSDestroy(s *terraform.State) error {
 	client := test.AccClientGetter()
 	keyOp := kms.NewKeyOp(client.KmsClient)
@@ -215,4 +247,16 @@ resource "sakura_kms" "foobar" {
   tags         = ["tag1", "tag2"]
   key_origin   = "imported"
   plain_key_wo = "AfL5zzjD4RgeFQm3vvAADwPNrurNUc616877wsa8v4w="
+}`
+
+var testAccSakuraKMS_tagsIssue = `
+resource "sakura_kms" "foobar" {
+  name        = "{{ .arg0 }}"
+  description = "description"
+}`
+
+var testAccSakuraKMS_tagsIssueUpdate = `
+resource "sakura_kms" "foobar" {
+  name        = "{{ .arg0 }}"
+  description = "description-updated"
 }`

--- a/internal/service/kms/resource_test.go
+++ b/internal/service/kms/resource_test.go
@@ -158,6 +158,50 @@ func TestAccSakuraResourceKMS_tagsIssue(t *testing.T) {
 	})
 }
 
+func TestAccImportSakuraResourceKMS_basic(t *testing.T) {
+	rand := test.RandomName()
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+		expects := map[string]string{
+			"name":           rand,
+			"description":    "description",
+			"tags.#":         "2",
+			"tags.0":         "tag1",
+			"tags.1":         "tag2",
+			"latest_version": "0",
+			"rotate_version": "0",
+			"key_origin":     "generated",
+			"status":         "active",
+		}
+
+		if err := test.CompareStateMulti(s[0], expects); err != nil {
+			return err
+		}
+		return test.StateNotEmptyMulti(s[0], "created_at", "modified_at")
+	}
+
+	resourceName := "sakura_kms.foobar"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraKMSDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraKMS_basic, rand),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateCheck:  checkFn,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckSakuraKMSDestroy(s *terraform.State) error {
 	client := test.AccClientGetter()
 	keyOp := kms.NewKeyOp(client.KmsClient)


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

KMSのOpenAPI定義の更新に伴い、Update時にtagsがrequiredになってた変更に対する修正。
また、rotate_versionを過去に足した影響でimportで差分が出るようになってたのでそこも修正。

### ドキュメントの変更は必要ですか？

必要無し