### PR TITLE
fix(secret_manager): support composite ID for import and add tests

### DIFF
--- a/internal/service/s3cret_manager/resource_s3cret.go
+++ b/internal/service/s3cret_manager/resource_s3cret.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
@@ -105,7 +106,17 @@ func (r *secretManagerSecretResource) Schema(ctx context.Context, req resource.S
 }
 
 func (r *secretManagerSecretResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughWithIdentity(ctx, path.Root("name"), path.Root("name"), req, resp)
+	parts := strings.SplitN(req.ID, "/", 2)
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"ImportState Error",
+			fmt.Sprintf("Invalid import ID format: %s. Expected format: vault_id/name", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("vault_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), parts[1])...)
 }
 
 func (r *secretManagerSecretResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/service/s3cret_manager/resource_s3cret.go
+++ b/internal/service/s3cret_manager/resource_s3cret.go
@@ -62,7 +62,13 @@ type secretManagerSecretResourceModel struct {
 func (r *secretManagerSecretResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"name": common.SchemaResourceName("Secret Manager's secret"),
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "The name of the Secret Manager's secret.",
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 255),
+				},
+			},
 			"vault_id": schema.StringAttribute{
 				Required:    true,
 				Description: "The Secret Manager's vault id.",

--- a/internal/service/s3cret_manager/resource_s3cret.go
+++ b/internal/service/s3cret_manager/resource_s3cret.go
@@ -115,8 +115,24 @@ func (r *secretManagerSecretResource) ImportState(ctx context.Context, req resou
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("vault_id"), parts[0])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), parts[1])...)
+	vaultID := parts[0]
+	name := parts[1]
+
+	if vaultID == "" {
+		resp.Diagnostics.AddError("ImportState Error", "vault_id must not be empty")
+		return
+	}
+	if name == "" {
+		resp.Diagnostics.AddError("ImportState Error", "name must not be empty")
+		return
+	}
+	if len(name) > 255 {
+		resp.Diagnostics.AddError("ImportState Error", "name must be 255 characters or less")
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("vault_id"), vaultID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
 }
 
 func (r *secretManagerSecretResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/service/s3cret_manager/resource_s3cret_test.go
+++ b/internal/service/s3cret_manager/resource_s3cret_test.go
@@ -85,6 +85,38 @@ func TestAccSakuraSecretManagerSecret_basicWithWO(t *testing.T) {
 	})
 }
 
+func TestAccImportSakuraSecretManagerSecret_basic(t *testing.T) {
+	resourceName := "sakura_secret_manager_secret.foobar"
+	rand := test.RandomName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraSecretManagerSecretDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraSecretManagerSecret_import, rand),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+				ImportStateVerifyIgnore: []string{
+					"value",
+				},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("resource not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["vault_id"], rs.Primary.Attributes["name"]), nil
+				},
+			},
+		},
+	})
+}
+
 func testCheckSakuraSecretManagerSecretDestroy(s *terraform.State) error {
 	client := test.AccClientGetter()
 	ctx := context.Background()
@@ -132,6 +164,29 @@ func testCheckSakuraSecretManagerSecretExists(n string, secret *v1.Secret) resou
 		return nil
 	}
 }
+
+//nolint:gosec
+var testAccSakuraSecretManagerSecret_import = `
+resource "sakura_kms" "foobar" {
+  name        = "{{ .arg0 }}"
+  description = "description"
+}
+
+resource "sakura_secret_manager" "foobar" {
+  name        = "{{ .arg0 }}"
+  description = "description"
+  kms_key_id  = sakura_kms.foobar.id
+
+  depends_on = [sakura_kms.foobar]
+}
+
+resource "sakura_secret_manager_secret" "foobar" {
+  name     = "{{ .arg0 }}"
+  value    = "value1"
+  vault_id = sakura_secret_manager.foobar.id
+
+  depends_on = [sakura_secret_manager.foobar]
+}`
 
 //nolint:gosec
 var testAccSakuraSecretManagerSecret_basic = `

--- a/internal/service/s3cret_manager/resource_test.go
+++ b/internal/service/s3cret_manager/resource_test.go
@@ -53,6 +53,27 @@ func TestAccSakuraSecretManager_basic(t *testing.T) {
 	})
 }
 
+func TestAccImportSakuraSecretManager_basic(t *testing.T) {
+	resourceName := "sakura_secret_manager.foobar"
+	rand := test.RandomName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraSecretManagerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraSecretManager_import, rand),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckSakuraSecretManagerDestroy(s *terraform.State) error {
 	client := test.AccClientGetter()
 	vaultOp := sm.NewVaultOp(client.SecretManagerClient)
@@ -101,6 +122,23 @@ func testCheckSakuraSecretManagerExists(n string, vault *v1.Vault) resource.Test
 		return nil
 	}
 }
+
+//nolint:gosec
+var testAccSakuraSecretManager_import = `
+resource "sakura_kms" "foobar" {
+  name        = "{{ .arg0 }}"
+  description = "description"
+  tags        = ["tag1", "tag2"]
+}
+
+resource "sakura_secret_manager" "foobar" {
+  name        = "{{ .arg0 }}"
+  description = "description"
+  tags        = ["tag1", "tag2"]
+  kms_key_id  = sakura_kms.foobar.id
+
+  depends_on = [sakura_kms.foobar]
+}`
 
 //nolint:gosec
 var testAccSakuraSecretManager_basic = `


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

関連: #158 

### このPRはどういう変更を行いますか？

https://github.com/sacloud/terraform-provider-sakura/issues/158 対応の一環としてまずはterraform-provider-sakuracloud (v2) と当プロバイダー(v3)の両方に存在するリソースについてimport のテスト強化と必要なら修正を行っています。

このPRではシークレットマネージャ関連の修正を行っています。

- `sakura_secret_manager_secret` の `ImportState` で composite ID (`vault_id/name`) をサポートするように修正
- `sakura_secret_manager` と `sakura_secret_manager_secret` の import verification テストを追加
- テストテンプレート変数に `//nolint:gosec` を追加し、false positive を抑制

### ドキュメントの変更は必要ですか？

不要