### PR TITLE
fix(webaccel): make logging write-only attributes optional for import support

### DIFF
--- a/internal/service/webaccel/resource.go
+++ b/internal/service/webaccel/resource.go
@@ -238,7 +238,7 @@ func (r *webAccelResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 						Description: "Object Storage's bucket name",
 					},
 					"access_key_wo": schema.StringAttribute{
-						Required:    true,
+						Optional:    true,
 						WriteOnly:   true,
 						Description: "Object Storage's access key",
 						Validators: []validator.String{
@@ -246,7 +246,7 @@ func (r *webAccelResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 						},
 					},
 					"secret_access_key_wo": schema.StringAttribute{
-						Required:    true,
+						Optional:    true,
 						WriteOnly:   true,
 						Description: "Object Storage's secret access key",
 						Validators: []validator.String{
@@ -512,9 +512,11 @@ func (r *webAccelResource) Update(ctx context.Context, req resource.UpdateReques
 			}
 		} else {
 			logReq := expandLoggingParameters(&plan, &config)
-			if _, err := op.ApplyLogUploadConfig(ctx, state.ID.ValueString(), logReq); err != nil {
-				resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to apply logging config for WebAccel site[%s]: %s", state.ID.ValueString(), err))
-				return
+			if logReq != nil {
+				if _, err := op.ApplyLogUploadConfig(ctx, state.ID.ValueString(), logReq); err != nil {
+					resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to apply logging config for WebAccel site[%s]: %s", state.ID.ValueString(), err))
+					return
+				}
 			}
 		}
 	}
@@ -566,7 +568,10 @@ func (m *webAccelResourceModel) updateModel(site *webaccel.Site, logUploadConfig
 	m.OriginParameters = originParams
 
 	if logUploadConfig != nil {
-		ver := m.Logging.CredentialsWOVersion // preserve the version in state when log upload config exists
+		var ver types.Int32
+		if m.Logging != nil {
+			ver = m.Logging.CredentialsWOVersion // preserve the version in state when log upload config exists
+		}
 		m.Logging = flattenWebAccelLogUploadConfig(logUploadConfig)
 		m.Logging.CredentialsWOVersion = ver
 	} else {
@@ -719,6 +724,11 @@ func expandLoggingParameters(plan, config *webAccelResourceModel) *webaccel.LogU
 		logCfgKeys = config.Logging
 	}
 
+	// Skip if credentials are not set (e.g. after import)
+	if !utils.IsKnown(logCfgKeys.AccessKeyWO) || !utils.IsKnown(logCfgKeys.SecretAccessKeyWO) {
+		return nil
+	}
+
 	req := new(webaccel.LogUploadConfig)
 	if logCfg.Enabled.ValueBool() {
 		req.Status = "enabled"
@@ -791,15 +801,17 @@ func flattenWebAccelOriginParameters(config *webAccelResourceModel, site *webacc
 		originParam.Region = types.StringValue(site.S3Region)
 		originParam.BucketName = types.StringValue(site.BucketName)
 
-		if config == nil || config.OriginParameters == nil {
-			return nil, fmt.Errorf("origin_parameters must be provided to keep bucket credentials")
-		}
-		confParam := config.OriginParameters
-		if utils.IsKnown(confParam.UseDocumentIndex) {
-			originParam.UseDocumentIndex = types.BoolValue(confParam.UseDocumentIndex.ValueBool())
-		}
-		if utils.IsKnown(confParam.CredentialsWOVersion) {
-			originParam.CredentialsWOVersion = types.Int32Value(confParam.CredentialsWOVersion.ValueInt32())
+		if config != nil && config.OriginParameters != nil {
+			confParam := config.OriginParameters
+			if utils.IsKnown(confParam.UseDocumentIndex) {
+				originParam.UseDocumentIndex = types.BoolValue(confParam.UseDocumentIndex.ValueBool())
+			}
+			if utils.IsKnown(confParam.CredentialsWOVersion) {
+				originParam.CredentialsWOVersion = types.Int32Value(confParam.CredentialsWOVersion.ValueInt32())
+			}
+		} else {
+			// Import state: populate UseDocumentIndex from API response
+			originParam.UseDocumentIndex = types.BoolValue(site.DocIndex == webaccel.DocIndexEnabled)
 		}
 	default:
 		return nil, fmt.Errorf("unknown origin type: %s", site.OriginType)

--- a/internal/service/webaccel/resource.go
+++ b/internal/service/webaccel/resource.go
@@ -822,6 +822,9 @@ func flattenWebAccelOriginParameters(config *webAccelResourceModel, site *webacc
 			if utils.IsKnown(confParam.CredentialsWOVersion) {
 				originParam.CredentialsWOVersion = types.Int32Value(confParam.CredentialsWOVersion.ValueInt32())
 			}
+		} else {
+			// Import state: keep UseDocumentIndex unset to avoid forcing diffs when users omit this optional field after import
+			originParam.UseDocumentIndex = types.BoolNull()
 		}
 	default:
 		return nil, fmt.Errorf("unknown origin type: %s", site.OriginType)

--- a/internal/service/webaccel/resource.go
+++ b/internal/service/webaccel/resource.go
@@ -519,11 +519,17 @@ func (r *webAccelResource) Update(ctx context.Context, req resource.UpdateReques
 			}
 		} else {
 			logReq := expandLoggingParameters(&plan, &config)
-			if logReq != nil {
-				if _, err := op.ApplyLogUploadConfig(ctx, state.ID.ValueString(), logReq); err != nil {
-					resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to apply logging config for WebAccel site[%s]: %s", state.ID.ValueString(), err))
-					return
-				}
+			if logReq == nil {
+				resp.Diagnostics.AddError(
+					"Update: Missing logging credentials",
+					"logging block requires access_key_wo and secret_access_key_wo to apply changes. "+
+						"These values cannot be retrieved from API after import. Please set them manually.",
+				)
+				return
+			}
+			if _, err := op.ApplyLogUploadConfig(ctx, state.ID.ValueString(), logReq); err != nil {
+				resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to apply logging config for WebAccel site[%s]: %s", state.ID.ValueString(), err))
+				return
 			}
 		}
 	}

--- a/internal/service/webaccel/resource.go
+++ b/internal/service/webaccel/resource.go
@@ -822,9 +822,6 @@ func flattenWebAccelOriginParameters(config *webAccelResourceModel, site *webacc
 			if utils.IsKnown(confParam.CredentialsWOVersion) {
 				originParam.CredentialsWOVersion = types.Int32Value(confParam.CredentialsWOVersion.ValueInt32())
 			}
-		} else {
-			// Import state: keep UseDocumentIndex unset to avoid forcing diffs when users omit this optional field after import
-			originParam.UseDocumentIndex = types.BoolNull()
 		}
 	default:
 		return nil, fmt.Errorf("unknown origin type: %s", site.OriginType)

--- a/internal/service/webaccel/resource.go
+++ b/internal/service/webaccel/resource.go
@@ -391,6 +391,13 @@ func (r *webAccelResource) Create(ctx context.Context, req resource.CreateReques
 
 	if hasLoggingConfig {
 		logReq := expandLoggingParameters(&plan, &config)
+		if logReq == nil {
+			resp.Diagnostics.AddError(
+				"Create: Invalid logging configuration",
+				"logging block is present but access_key_wo and secret_access_key_wo are required to configure logging",
+			)
+			return
+		}
 		if _, err := op.ApplyLogUploadConfig(ctx, created.ID, logReq); err != nil {
 			resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to apply logging config for WebAccel site: %s", err))
 			return
@@ -568,9 +575,9 @@ func (m *webAccelResourceModel) updateModel(site *webaccel.Site, logUploadConfig
 	m.OriginParameters = originParams
 
 	if logUploadConfig != nil {
-		var ver types.Int32
-		if m.Logging != nil {
-			ver = m.Logging.CredentialsWOVersion // preserve the version in state when log upload config exists
+		ver := types.Int32Null()
+		if m.Logging != nil && utils.IsKnown(m.Logging.CredentialsWOVersion) {
+			ver = m.Logging.CredentialsWOVersion
 		}
 		m.Logging = flattenWebAccelLogUploadConfig(logUploadConfig)
 		m.Logging.CredentialsWOVersion = ver

--- a/internal/service/webaccel/resource.go
+++ b/internal/service/webaccel/resource.go
@@ -240,7 +240,7 @@ func (r *webAccelResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 					"access_key_wo": schema.StringAttribute{
 						Optional:    true,
 						WriteOnly:   true,
-						Description: "Object Storage's access key",
+						Description: "Object Storage's access key. Required when configuring logging.",
 						Validators: []validator.String{
 							stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("credentials_wo_version")),
 						},
@@ -248,7 +248,7 @@ func (r *webAccelResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 					"secret_access_key_wo": schema.StringAttribute{
 						Optional:    true,
 						WriteOnly:   true,
-						Description: "Object Storage's secret access key",
+						Description: "Object Storage's secret access key. Required when configuring logging.",
 						Validators: []validator.String{
 							stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("credentials_wo_version")),
 						},
@@ -822,9 +822,6 @@ func flattenWebAccelOriginParameters(config *webAccelResourceModel, site *webacc
 			if utils.IsKnown(confParam.CredentialsWOVersion) {
 				originParam.CredentialsWOVersion = types.Int32Value(confParam.CredentialsWOVersion.ValueInt32())
 			}
-		} else {
-			// Import state: populate UseDocumentIndex from API response
-			originParam.UseDocumentIndex = types.BoolValue(site.DocIndex == webaccel.DocIndexEnabled)
 		}
 	default:
 		return nil, fmt.Errorf("unknown origin type: %s", site.OriginType)

--- a/internal/service/webaccel/resource_acl_test.go
+++ b/internal/service/webaccel/resource_acl_test.go
@@ -16,15 +16,7 @@ import (
 )
 
 func TestAccResourceSakuraWebAccelACL_basic(t *testing.T) {
-	envKeys := []string{
-		envWebAccelSiteName,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelSiteName)
 
 	siteName := os.Getenv(envWebAccelSiteName)
 

--- a/internal/service/webaccel/resource_activation_test.go
+++ b/internal/service/webaccel/resource_activation_test.go
@@ -16,15 +16,7 @@ import (
 )
 
 func TestAccResourceSakuraWebAccelActivation_Basic(t *testing.T) {
-	envKeys := []string{
-		envWebAccelSiteName,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelSiteName)
 
 	siteName := os.Getenv(envWebAccelSiteName)
 
@@ -44,15 +36,7 @@ func TestAccResourceSakuraWebAccelActivation_Basic(t *testing.T) {
 }
 
 func TestAccResourceSakuraWebAccelActivation_Update(t *testing.T) {
-	envKeys := []string{
-		envWebAccelSiteName,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelSiteName)
 
 	siteName := os.Getenv(envWebAccelSiteName)
 

--- a/internal/service/webaccel/resource_certificate_test.go
+++ b/internal/service/webaccel/resource_certificate_test.go
@@ -24,19 +24,7 @@ const (
 )
 
 func TestAccResourceSakuraWebAccelCertificate_basic(t *testing.T) {
-	envKeys := []string{
-		envWebAccelSiteName,
-		envWebAccelCertificateCrt,
-		envWebAccelCertificateKey,
-		envWebAccelCertificateCrtUpd,
-		envWebAccelCertificateKeyUpd,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelSiteName, envWebAccelCertificateCrt, envWebAccelCertificateKey, envWebAccelCertificateCrtUpd, envWebAccelCertificateKeyUpd)
 
 	siteName := os.Getenv(envWebAccelSiteName)
 	crt := os.Getenv(envWebAccelCertificateCrt)

--- a/internal/service/webaccel/resource_test.go
+++ b/internal/service/webaccel/resource_test.go
@@ -31,15 +31,7 @@ const (
 func TestAccSakuraResourceWebAccel_WebOrigin(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelOrigin)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -90,16 +82,7 @@ func testCheckSakuraWebAccelDestroy(s *terraform.State) error {
 func TestAccSakuraResourceWebAccel_OwnDomain(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-		envWebAccelDomainName,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelOrigin, envWebAccelDomainName)
 
 	siteName := "your-site-name"
 	origin := os.Getenv(envWebAccelOrigin)
@@ -130,15 +113,7 @@ func TestAccSakuraResourceWebAccel_OwnDomain(t *testing.T) {
 func TestAccSakuraResourceWebAccel_WebOriginWithOneTimeUrlSecrets(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelOrigin)
 
 	siteName := "your-site-name"
 	origin := os.Getenv(envWebAccelOrigin)
@@ -165,15 +140,7 @@ func TestAccSakuraResourceWebAccel_WebOriginWithOneTimeUrlSecrets(t *testing.T) 
 func TestAccSakuraResourceWebAccel_WebOriginWithCORS(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelOrigin)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -204,20 +171,9 @@ func TestAccSakuraResourceWebAccel_WebOriginWithCORS(t *testing.T) {
 func TestAccSakuraResourceWebAccel_Update(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-		envObjectStorageEndpoint,
-		envObjectStorageRegion,
-		envObjectStorageBucketName,
-		envObjectStorageAccessKeyId,
-		envObjectStorageSecretAccessKey,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelOrigin, envObjectStorageEndpoint,
+		envObjectStorageRegion, envObjectStorageBucketName,
+		envObjectStorageAccessKeyId, envObjectStorageSecretAccessKey)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -286,20 +242,9 @@ func TestAccSakuraResourceWebAccel_Update(t *testing.T) {
 func TestAccSakuraResourceWebAccel_BucketOrigin(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-		envObjectStorageEndpoint,
-		envObjectStorageRegion,
-		envObjectStorageBucketName,
-		envObjectStorageAccessKeyId,
-		envObjectStorageSecretAccessKey,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelOrigin, envObjectStorageEndpoint,
+		envObjectStorageRegion, envObjectStorageBucketName,
+		envObjectStorageAccessKeyId, envObjectStorageSecretAccessKey)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -335,20 +280,9 @@ func TestAccSakuraResourceWebAccel_BucketOrigin(t *testing.T) {
 func TestAccSakuraResourceWebAccel_Logging(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-		envObjectStorageEndpoint,
-		envObjectStorageRegion,
-		envObjectStorageBucketName,
-		envObjectStorageAccessKeyId,
-		envObjectStorageSecretAccessKey,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelOrigin, envObjectStorageEndpoint,
+		envObjectStorageRegion, envObjectStorageBucketName,
+		envObjectStorageAccessKeyId, envObjectStorageSecretAccessKey)
 
 	siteName := "your-site-name"
 	origin := os.Getenv(envWebAccelOrigin)
@@ -378,10 +312,7 @@ func TestAccSakuraResourceWebAccel_Logging(t *testing.T) {
 }
 
 func TestAccSakuraResourceWebAccel_InvalidConfigurations(t *testing.T) {
-	if os.Getenv(envWebAccelOrigin) == "" {
-		t.Skipf("ENV %q is required. skip", envWebAccelOrigin)
-		return
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelOrigin)
 	origin := os.Getenv(envWebAccelOrigin)
 	for name, tc := range testAccCheckSakuraWebAccelInvalidConfigs(origin) {
 		t.Logf("test for invalid configuration: %s", name)
@@ -776,15 +707,7 @@ resource sakura_webaccel "foobar" {
 func TestAccImportSakuraWebAccel_basic(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelOrigin)
 
 	siteName := "your-site-name"
 	origin := os.Getenv(envWebAccelOrigin)
@@ -819,20 +742,9 @@ func TestAccImportSakuraWebAccel_basic(t *testing.T) {
 func TestAccImportSakuraWebAccel_bucketOrigin(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-		envObjectStorageEndpoint,
-		envObjectStorageRegion,
-		envObjectStorageBucketName,
-		envObjectStorageAccessKeyId,
-		envObjectStorageSecretAccessKey,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelOrigin, envObjectStorageEndpoint,
+		envObjectStorageRegion, envObjectStorageBucketName,
+		envObjectStorageAccessKeyId, envObjectStorageSecretAccessKey)
 
 	siteName := "your-site-name"
 	endpoint, _ := strings.CutPrefix(os.Getenv(envObjectStorageEndpoint), "https://")
@@ -871,20 +783,9 @@ func TestAccImportSakuraWebAccel_bucketOrigin(t *testing.T) {
 func TestAccImportSakuraWebAccel_withLogging(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
 
-	envKeys := []string{
-		envWebAccelOrigin,
-		envObjectStorageEndpoint,
-		envObjectStorageRegion,
-		envObjectStorageBucketName,
-		envObjectStorageAccessKeyId,
-		envObjectStorageSecretAccessKey,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	test.SkipIfEnvIsNotSet(t, envWebAccelOrigin, envObjectStorageEndpoint,
+		envObjectStorageRegion, envObjectStorageBucketName,
+		envObjectStorageAccessKeyId, envObjectStorageSecretAccessKey)
 
 	siteName := "your-site-name"
 	origin := os.Getenv(envWebAccelOrigin)

--- a/internal/service/webaccel/resource_test.go
+++ b/internal/service/webaccel/resource_test.go
@@ -768,3 +768,98 @@ resource sakura_webaccel "foobar" {
 
 	return tt
 }
+
+func TestAccImportSakuraWebAccel_basic(t *testing.T) {
+	test.SkipIfFakeModeEnabled(t)
+
+	envKeys := []string{
+		envWebAccelOrigin,
+	}
+	for _, k := range envKeys {
+		if os.Getenv(k) == "" {
+			t.Skipf("ENV %q is required. skip", k)
+			return
+		}
+	}
+
+	siteName := "your-site-name"
+	origin := os.Getenv(envWebAccelOrigin)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraWebAccelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckSakuraWebAccelWebOriginConfigBasic(siteName, origin),
+			},
+			{
+				ResourceName:      "sakura_webaccel.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"onetime_url_secrets_wo",
+					"onetime_url_secrets_wo_version",
+					"origin_parameters.access_key_wo",
+					"origin_parameters.secret_access_key_wo",
+					"origin_parameters.credentials_wo_version",
+					"logging.access_key_wo",
+					"logging.secret_access_key_wo",
+					"logging.credentials_wo_version",
+				},
+			},
+		},
+	})
+}
+
+func TestAccImportSakuraWebAccel_bucketOrigin(t *testing.T) {
+	test.SkipIfFakeModeEnabled(t)
+
+	envKeys := []string{
+		envWebAccelOrigin,
+		envObjectStorageEndpoint,
+		envObjectStorageRegion,
+		envObjectStorageBucketName,
+		envObjectStorageAccessKeyId,
+		envObjectStorageSecretAccessKey,
+	}
+	for _, k := range envKeys {
+		if os.Getenv(k) == "" {
+			t.Skipf("ENV %q is required. skip", k)
+			return
+		}
+	}
+
+	siteName := "your-site-name"
+	endpoint, _ := strings.CutPrefix(os.Getenv(envObjectStorageEndpoint), "https://")
+	region := os.Getenv(envObjectStorageRegion)
+	bucketName := os.Getenv(envObjectStorageBucketName)
+	accessKey := os.Getenv(envObjectStorageAccessKeyId)
+	secretKey := os.Getenv(envObjectStorageSecretAccessKey)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraWebAccelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckSakuraWebAccelBucketOriginConfig(siteName, endpoint, region, bucketName, accessKey, secretKey),
+			},
+			{
+				ResourceName:      "sakura_webaccel.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"onetime_url_secrets_wo",
+					"onetime_url_secrets_wo_version",
+					"origin_parameters.access_key_wo",
+					"origin_parameters.secret_access_key_wo",
+					"origin_parameters.credentials_wo_version",
+					"logging.access_key_wo",
+					"logging.secret_access_key_wo",
+					"logging.credentials_wo_version",
+				},
+			},
+		},
+	})
+}

--- a/internal/service/webaccel/resource_test.go
+++ b/internal/service/webaccel/resource_test.go
@@ -863,3 +863,56 @@ func TestAccImportSakuraWebAccel_bucketOrigin(t *testing.T) {
 		},
 	})
 }
+
+func TestAccImportSakuraWebAccel_withLogging(t *testing.T) {
+	test.SkipIfFakeModeEnabled(t)
+
+	envKeys := []string{
+		envWebAccelOrigin,
+		envObjectStorageEndpoint,
+		envObjectStorageRegion,
+		envObjectStorageBucketName,
+		envObjectStorageAccessKeyId,
+		envObjectStorageSecretAccessKey,
+	}
+	for _, k := range envKeys {
+		if os.Getenv(k) == "" {
+			t.Skipf("ENV %q is required. skip", k)
+			return
+		}
+	}
+
+	siteName := "your-site-name"
+	origin := os.Getenv(envWebAccelOrigin)
+	endpoint, _ := strings.CutPrefix(os.Getenv(envObjectStorageEndpoint), "https://")
+	region := os.Getenv(envObjectStorageRegion)
+	bucketName := os.Getenv(envObjectStorageBucketName)
+	accessKey := os.Getenv(envObjectStorageAccessKeyId)
+	secretKey := os.Getenv(envObjectStorageSecretAccessKey)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraWebAccelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckSakuraWebAccelWebOriginLoggingConfig(siteName, origin, endpoint, region, bucketName, accessKey, secretKey),
+			},
+			{
+				ResourceName:      "sakura_webaccel.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"onetime_url_secrets_wo",
+					"onetime_url_secrets_wo_version",
+					"origin_parameters.access_key_wo",
+					"origin_parameters.secret_access_key_wo",
+					"origin_parameters.credentials_wo_version",
+					"logging.access_key_wo",
+					"logging.secret_access_key_wo",
+					"logging.credentials_wo_version",
+				},
+			},
+		},
+	})
+}

--- a/internal/service/webaccel/resource_test.go
+++ b/internal/service/webaccel/resource_test.go
@@ -337,6 +337,8 @@ func TestAccSakuraResourceWebAccel_Logging(t *testing.T) {
 
 	envKeys := []string{
 		envWebAccelOrigin,
+		envObjectStorageEndpoint,
+		envObjectStorageRegion,
 		envObjectStorageBucketName,
 		envObjectStorageAccessKeyId,
 		envObjectStorageSecretAccessKey,
@@ -350,6 +352,8 @@ func TestAccSakuraResourceWebAccel_Logging(t *testing.T) {
 
 	siteName := "your-site-name"
 	origin := os.Getenv(envWebAccelOrigin)
+	endpoint, _ := strings.CutPrefix(os.Getenv(envObjectStorageEndpoint), "https://")
+	region := os.Getenv(envObjectStorageRegion)
 	bucketName := os.Getenv(envObjectStorageBucketName)
 	accessKey := os.Getenv(envObjectStorageAccessKeyId)
 	secretKey := os.Getenv(envObjectStorageSecretAccessKey)
@@ -360,7 +364,7 @@ func TestAccSakuraResourceWebAccel_Logging(t *testing.T) {
 		CheckDestroy:             testCheckSakuraWebAccelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckSakuraWebAccelWebOriginLoggingConfig(siteName, origin, "s3.isk01.sakurastorage.jp", "jp-north-1", bucketName, accessKey, secretKey),
+				Config: testAccCheckSakuraWebAccelWebOriginLoggingConfig(siteName, origin, endpoint, region, bucketName, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sakura_webaccel.foobar", "name", siteName),
 					resource.TestCheckResourceAttr("sakura_webaccel.foobar", "origin_parameters.type", "web"),


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

関連: #158

### なぜこの変更が必要か

`sakura_webaccel` リソースの `logging` ブロック内にある `access_key_wo` と `secret_access_key_wo` は `Required: true` で定義されていましたが、これにより `terraform import` 時に以下の問題が発生していました：

1. **write-only 属性は import 時に設定できない**
   `terraform import` コマンドでは write-only 属性の値を渡せません。また、import 後の `Read` で API からこれらの値を復元することもできません（API が返さないため）。Required な属性が空のままになると、`ImportStateVerify` で「必須属性が設定されていない」という plan diff エラーとなります。

2. **Update 時に空の認証情報で API を誤って呼び出す**
   import 後、ユーザーが `logging` ブロックを含まない設定で plan/apply した場合、`expandLoggingParameters` が空の認証情報で API を呼び出そうとし、不正なリクエストとしてエラーになる可能性がありました。

3. **import 時の nil pointer dereference リスク**
   API レスポンスに logging 設定が含まれない場合、`updateModel` 内で nil の `Logging` ポインタにアクセスし panic する可能性がありました。

これらの問題を解決するため、write-only 属性を `Optional` に変更し、import 時およびその後の管理において安全に動作するよう修正しています。

### このPRはどういう変更を行いますか？

- `logging.access_key_wo` と `logging.secret_access_key_wo` を `Required` から `Optional` に変更し、import 時に設定不要にする
- `expandLoggingParameters` で認証情報が不足している場合に API コールをスキップするように修正
- `flattenWebAccelOriginParameters` で import 時の config 不在状態を安全にハンドリング
- `updateModel` で nil の `Logging` ポインターをガードするように修正
- `sakura_webaccel` の import verification テストを追加

### ドキュメントの変更は必要ですか？

不要