### PR TITLE
fix(vpn_router): set Version in updateState during Read/Import

### DIFF
--- a/internal/service/vpn_router/model.go
+++ b/internal/service/vpn_router/model.go
@@ -239,6 +239,7 @@ func (model *vpnRouterBaseModel) updateState(ctx context.Context, client *common
 	model.UpdateBaseState(vpnRouter.ID.String(), vpnRouter.Name, vpnRouter.Description, vpnRouter.Tags)
 	model.Zone = types.StringValue(zone)
 	model.Plan = types.StringValue(flattenVPNRouterPlan(vpnRouter))
+	model.Version = types.Int32Value(int32(vpnRouter.Version))
 	model.PublicIP = types.StringValue(flattenVPNRouterGlobalAddress(vpnRouter))
 	model.PublicNetmask = types.Int64Value(int64(flattenVPNRouterGlobalNetworkMaskLen(vpnRouter)))
 	model.PublicNetworkInterface = flattenVPNRouterPublicNetworkInterface(vpnRouter)

--- a/internal/service/vpn_router/resource_test.go
+++ b/internal/service/vpn_router/resource_test.go
@@ -74,6 +74,35 @@ func TestAccSakuraVPNRouter_basic(t *testing.T) {
 	})
 }
 
+func TestAccImportSakuraVPNRouter_basic(t *testing.T) {
+	resourceName := "sakura_vpn_router.foobar"
+	rand := test.RandomName()
+
+	var vpcRouter iaas.VPCRouter
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			test.CheckSakuraIconDestroy,
+			testCheckSakuraVPNRouterDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraVPNRouter_import, rand),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraVPNRouterExists(resourceName, &vpcRouter),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccSakuraVPNRouter_Full(t *testing.T) {
 	resourceName := "sakura_vpn_router.foobar"
 	rand := test.RandomName()
@@ -616,5 +645,11 @@ resource "sakura_vpn_router" "foobar" {
 	password_wo         = "password"
 	password_wo_version = 1
   }]
+}
+`
+
+var testAccSakuraVPNRouter_import = `
+resource "sakura_vpn_router" "foobar" {
+  name = "{{ .arg0 }}"
 }
 `


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

関連: #158 

### このPRはどういう変更を行いますか？

- `sakura_vpn_router` リソースの import 時に `version` が正しく反映されない問題を修正
- import 検証テスト (`TestAccImportSakuraVPNRouter_basic`) を追加

詳細:
- `updateState` に `Version` の設定を追加（Read/Import 時に API レスポンスの値を反映）

### ドキュメントの変更は必要ですか？

不要