### PR TITLE
test: add import verification test for sakura_secret_manager resource

### DIFF
--- a/internal/service/s3cret_manager/resource_test.go
+++ b/internal/service/s3cret_manager/resource_test.go
@@ -53,6 +53,26 @@ func TestAccSakuraSecretManager_basic(t *testing.T) {
 	})
 }
 
+func TestAccImportSakuraSecretManager_basic(t *testing.T) {
+	rand := test.RandomName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraSecretManagerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraSecretManager_basic, rand),
+			},
+			{
+				ResourceName:      "sakura_secret_manager.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckSakuraSecretManagerDestroy(s *terraform.State) error {
 	client := test.AccClientGetter()
 	vaultOp := sm.NewVaultOp(client.SecretManagerClient)

--- a/internal/service/vpn_router/model.go
+++ b/internal/service/vpn_router/model.go
@@ -239,6 +239,7 @@ func (model *vpnRouterBaseModel) updateState(ctx context.Context, client *common
 	model.UpdateBaseState(vpnRouter.ID.String(), vpnRouter.Name, vpnRouter.Description, vpnRouter.Tags)
 	model.Zone = types.StringValue(zone)
 	model.Plan = types.StringValue(flattenVPNRouterPlan(vpnRouter))
+	model.Version = types.Int32Value(int32(vpnRouter.Version))
 	model.PublicIP = types.StringValue(flattenVPNRouterGlobalAddress(vpnRouter))
 	model.PublicNetmask = types.Int64Value(int64(flattenVPNRouterGlobalNetworkMaskLen(vpnRouter)))
 	model.PublicNetworkInterface = flattenVPNRouterPublicNetworkInterface(vpnRouter)

--- a/internal/service/vpn_router/resource_test.go
+++ b/internal/service/vpn_router/resource_test.go
@@ -74,6 +74,35 @@ func TestAccSakuraVPNRouter_basic(t *testing.T) {
 	})
 }
 
+func TestAccImportSakuraVPNRouter_basic(t *testing.T) {
+	resourceName := "sakura_vpn_router.foobar"
+	rand := test.RandomName()
+
+	var vpcRouter iaas.VPCRouter
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			test.CheckSakuraIconDestroy,
+			testCheckSakuraVPNRouterDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraVPNRouter_import, rand),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraVPNRouterExists(resourceName, &vpcRouter),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccSakuraVPNRouter_Full(t *testing.T) {
 	resourceName := "sakura_vpn_router.foobar"
 	rand := test.RandomName()
@@ -616,5 +645,11 @@ resource "sakura_vpn_router" "foobar" {
 	password_wo         = "password"
 	password_wo_version = 1
   }]
+}
+`
+
+var testAccSakuraVPNRouter_import = `
+resource "sakura_vpn_router" "foobar" {
+  name = "{{ .arg0 }}"
 }
 `


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

関連: #158

### このPRはどういう変更を行いますか？

`sakura_secret_manager` リソースの `ImportStateVerify` テスト (`TestAccImportSakuraSecretManager_basic`) を追加しました。

これにより、v2 から v3 へ移植されたリソースの中で未対応だった `secret_manager` 主リソースの import 検証が可能になります。

#253 の対応漏れです。

### ドキュメントの変更は必要ですか？

不要