### PR TITLE
fix(webaccel): support import for webaccel bucket origin

### DIFF
--- a/internal/service/webaccel/resource.go
+++ b/internal/service/webaccel/resource.go
@@ -791,15 +791,15 @@ func flattenWebAccelOriginParameters(config *webAccelResourceModel, site *webacc
 		originParam.Region = types.StringValue(site.S3Region)
 		originParam.BucketName = types.StringValue(site.BucketName)
 
-		if config == nil || config.OriginParameters == nil {
-			return nil, fmt.Errorf("origin_parameters must be provided to keep bucket credentials")
-		}
-		confParam := config.OriginParameters
-		if utils.IsKnown(confParam.UseDocumentIndex) {
-			originParam.UseDocumentIndex = types.BoolValue(confParam.UseDocumentIndex.ValueBool())
-		}
-		if utils.IsKnown(confParam.CredentialsWOVersion) {
-			originParam.CredentialsWOVersion = types.Int32Value(confParam.CredentialsWOVersion.ValueInt32())
+		// Restore values from config if available (importable attributes).
+		// Note: write-only credentials (access_key_wo, secret_access_key_wo) cannot be restored.
+		if config != nil && config.OriginParameters != nil {
+			if utils.IsKnown(config.OriginParameters.UseDocumentIndex) {
+				originParam.UseDocumentIndex = types.BoolValue(config.OriginParameters.UseDocumentIndex.ValueBool())
+			}
+			if utils.IsKnown(config.OriginParameters.CredentialsWOVersion) {
+				originParam.CredentialsWOVersion = types.Int32Value(config.OriginParameters.CredentialsWOVersion.ValueInt32())
+			}
 		}
 	default:
 		return nil, fmt.Errorf("unknown origin type: %s", site.OriginType)

--- a/internal/service/webaccel/resource_test.go
+++ b/internal/service/webaccel/resource_test.go
@@ -30,16 +30,9 @@ const (
 
 func TestAccSakuraResourceWebAccel_WebOrigin(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
-
-	envKeys := []string{
+	test.SkipIfEnvIsNotSet(t,
 		envWebAccelOrigin,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -90,16 +83,10 @@ func testCheckSakuraWebAccelDestroy(s *terraform.State) error {
 func TestAccSakuraResourceWebAccel_OwnDomain(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
 
-	envKeys := []string{
+	test.SkipIfEnvIsNotSet(t,
 		envWebAccelOrigin,
 		envWebAccelDomainName,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	)
 
 	siteName := "your-site-name"
 	origin := os.Getenv(envWebAccelOrigin)
@@ -129,16 +116,9 @@ func TestAccSakuraResourceWebAccel_OwnDomain(t *testing.T) {
 
 func TestAccSakuraResourceWebAccel_WebOriginWithOneTimeUrlSecrets(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
-
-	envKeys := []string{
+	test.SkipIfEnvIsNotSet(t,
 		envWebAccelOrigin,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	)
 
 	siteName := "your-site-name"
 	origin := os.Getenv(envWebAccelOrigin)
@@ -164,16 +144,9 @@ func TestAccSakuraResourceWebAccel_WebOriginWithOneTimeUrlSecrets(t *testing.T) 
 
 func TestAccSakuraResourceWebAccel_WebOriginWithCORS(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
-
-	envKeys := []string{
+	test.SkipIfEnvIsNotSet(t,
 		envWebAccelOrigin,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -203,21 +176,14 @@ func TestAccSakuraResourceWebAccel_WebOriginWithCORS(t *testing.T) {
 
 func TestAccSakuraResourceWebAccel_Update(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
-
-	envKeys := []string{
+	test.SkipIfEnvIsNotSet(t,
 		envWebAccelOrigin,
 		envObjectStorageEndpoint,
 		envObjectStorageRegion,
 		envObjectStorageBucketName,
 		envObjectStorageAccessKeyId,
 		envObjectStorageSecretAccessKey,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -285,21 +251,14 @@ func TestAccSakuraResourceWebAccel_Update(t *testing.T) {
 
 func TestAccSakuraResourceWebAccel_BucketOrigin(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
-
-	envKeys := []string{
+	test.SkipIfEnvIsNotSet(t,
 		envWebAccelOrigin,
 		envObjectStorageEndpoint,
 		envObjectStorageRegion,
 		envObjectStorageBucketName,
 		envObjectStorageAccessKeyId,
 		envObjectStorageSecretAccessKey,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	)
 
 	siteName := "your-site-name"
 	// domainName := os.Getenv(envWebAccelDomainName)
@@ -334,22 +293,19 @@ func TestAccSakuraResourceWebAccel_BucketOrigin(t *testing.T) {
 
 func TestAccSakuraResourceWebAccel_Logging(t *testing.T) {
 	test.SkipIfFakeModeEnabled(t)
-
-	envKeys := []string{
+	test.SkipIfEnvIsNotSet(t,
 		envWebAccelOrigin,
+		envObjectStorageEndpoint,
+		envObjectStorageRegion,
 		envObjectStorageBucketName,
 		envObjectStorageAccessKeyId,
 		envObjectStorageSecretAccessKey,
-	}
-	for _, k := range envKeys {
-		if os.Getenv(k) == "" {
-			t.Skipf("ENV %q is required. skip", k)
-			return
-		}
-	}
+	)
 
 	siteName := "your-site-name"
 	origin := os.Getenv(envWebAccelOrigin)
+	endpoint, _ := strings.CutPrefix(os.Getenv(envObjectStorageEndpoint), "https://")
+	region := os.Getenv(envObjectStorageRegion)
 	bucketName := os.Getenv(envObjectStorageBucketName)
 	accessKey := os.Getenv(envObjectStorageAccessKeyId)
 	secretKey := os.Getenv(envObjectStorageSecretAccessKey)
@@ -360,7 +316,7 @@ func TestAccSakuraResourceWebAccel_Logging(t *testing.T) {
 		CheckDestroy:             testCheckSakuraWebAccelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckSakuraWebAccelWebOriginLoggingConfig(siteName, origin, "s3.isk01.sakurastorage.jp", "jp-north-1", bucketName, accessKey, secretKey),
+				Config: testAccCheckSakuraWebAccelWebOriginLoggingConfig(siteName, origin, endpoint, region, bucketName, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sakura_webaccel.foobar", "name", siteName),
 					resource.TestCheckResourceAttr("sakura_webaccel.foobar", "origin_parameters.type", "web"),
@@ -396,6 +352,101 @@ func TestAccSakuraResourceWebAccel_InvalidConfigurations(t *testing.T) {
 			},
 		})
 	}
+}
+
+func TestAccImportSakuraWebAccel_WebOrigin(t *testing.T) {
+	test.SkipIfFakeModeEnabled(t)
+	test.SkipIfEnvIsNotSet(t,
+		envWebAccelOrigin,
+	)
+
+	siteName := "your-site-name"
+	origin := os.Getenv(envWebAccelOrigin)
+	resourceName := "sakura_webaccel.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraWebAccelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckSakuraWebAccelWebOriginConfigBasic(siteName, origin),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", siteName),
+					resource.TestCheckResourceAttr(resourceName, "origin_parameters.type", "web"),
+					resource.TestCheckResourceAttr(resourceName, "origin_parameters.origin", origin),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"onetime_url_secrets_wo",
+					"origin_parameters.access_key_wo",
+					"origin_parameters.secret_access_key_wo",
+					"origin_parameters.credentials_wo_version",
+					"origin_parameters.use_document_index",
+					"logging.access_key_wo",
+					"logging.secret_access_key_wo",
+					"logging.credentials_wo_version",
+				},
+			},
+		},
+	})
+}
+
+func TestAccImportSakuraWebAccel_BucketOrigin(t *testing.T) {
+	test.SkipIfFakeModeEnabled(t)
+	test.SkipIfEnvIsNotSet(t,
+		envWebAccelOrigin,
+		envObjectStorageEndpoint,
+		envObjectStorageRegion,
+		envObjectStorageBucketName,
+		envObjectStorageAccessKeyId,
+		envObjectStorageSecretAccessKey,
+	)
+
+	siteName := "your-site-name"
+	endpoint, _ := strings.CutPrefix(os.Getenv(envObjectStorageEndpoint), "https://")
+	region := os.Getenv(envObjectStorageRegion)
+	bucketName := os.Getenv(envObjectStorageBucketName)
+	accessKey := os.Getenv(envObjectStorageAccessKeyId)
+	secretKey := os.Getenv(envObjectStorageSecretAccessKey)
+	resourceName := "sakura_webaccel.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraWebAccelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckSakuraWebAccelBucketOriginConfig(siteName, endpoint, region, bucketName, accessKey, secretKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", siteName),
+					resource.TestCheckResourceAttr(resourceName, "origin_parameters.type", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "origin_parameters.endpoint", endpoint),
+					resource.TestCheckResourceAttr(resourceName, "origin_parameters.region", region),
+					resource.TestCheckResourceAttr(resourceName, "origin_parameters.bucket_name", bucketName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"onetime_url_secrets_wo",
+					"origin_parameters.access_key_wo",
+					"origin_parameters.secret_access_key_wo",
+					"origin_parameters.credentials_wo_version",
+					"origin_parameters.use_document_index",
+					"logging.access_key_wo",
+					"logging.secret_access_key_wo",
+					"logging.credentials_wo_version",
+				},
+			},
+		},
+	})
 }
 
 func testAccCheckSakuraWebAccelWebOriginConfigBasic(siteName string, origin string) string {


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #158

### このPRはどういう変更を行いますか？

#254 の出直しPRです。WebAccelリソースのimport対応を改善しました。
import時に以下のエラーが出ていた問題を解消しています。

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Read: API Error
│
│ origin_parameters must be provided to keep bucket credentials
```

#254 ではwrite-onlyの値の扱いを勘違い/思い違いしており、Required->Optionalへの変更を含めていましたが、改めて確認して不要であると理解したためPRからは除きました。

主な変更：
- `flattenWebAccelOriginParameters` を修正し、configがnilの場合（import時）でもエラーを返さず安全に処理するようにしました
- Web Origin と Bucket Origin の import verification テストを追加しました
- `ImportStateVerifyIgnore` に write-only フィールドと `use_document_index` を追加
- 既存テストの環境変数チェックを `test.SkipIfEnvIsNotSet` に統一
- Logging テストのエンドポイント/リージョンを環境変数から取得するように変更

E2Eテスト結果:

一部テストケースがSKIPされていますが、今回の修正と関係ない部分だと思います。

<details>

```
=== RUN   TestAccSakuraDataSourceWebAccel_ByName
    data_source_test.go:26: ENV "SAKURA_WEBACCEL_SITE_NAME" is required. skip
--- SKIP: TestAccSakuraDataSourceWebAccel_ByName (0.00s)
=== RUN   TestAccSakuraDataSourceWebAccel_ByDomain
    data_source_test.go:66: ENV "SAKURA_WEBACCEL_DOMAIN" is required. skip
--- SKIP: TestAccSakuraDataSourceWebAccel_ByDomain (0.00s)
=== RUN   TestAccSakuraResourceWebAccel_WebOrigin
--- PASS: TestAccSakuraResourceWebAccel_WebOrigin (8.62s)
=== RUN   TestAccSakuraResourceWebAccel_OwnDomain
    helper.go:32: Environment valiable "SAKURA_WEBACCEL_DOMAIN_NAME" is not set
--- SKIP: TestAccSakuraResourceWebAccel_OwnDomain (0.00s)
=== RUN   TestAccSakuraResourceWebAccel_WebOriginWithOneTimeUrlSecrets
--- PASS: TestAccSakuraResourceWebAccel_WebOriginWithOneTimeUrlSecrets (8.00s)
=== RUN   TestAccSakuraResourceWebAccel_WebOriginWithCORS
--- PASS: TestAccSakuraResourceWebAccel_WebOriginWithCORS (7.54s)
=== RUN   TestAccSakuraResourceWebAccel_Update
--- PASS: TestAccSakuraResourceWebAccel_Update (12.59s)
=== RUN   TestAccSakuraResourceWebAccel_BucketOrigin
--- PASS: TestAccSakuraResourceWebAccel_BucketOrigin (7.30s)
=== RUN   TestAccSakuraResourceWebAccel_Logging
--- PASS: TestAccSakuraResourceWebAccel_Logging (7.64s)
=== RUN   TestAccSakuraResourceWebAccel_InvalidConfigurations
    resource_test.go:339: test for invalid configuration: unknown-argument
    resource_test.go:339: test for invalid configuration: invalid-request-protocol
    resource_test.go:339: test for invalid configuration: no-origin-params
    resource_test.go:339: test for invalid configuration: invalid-origin-type
    resource_test.go:339: test for invalid configuration: lacking-web-origin-params
    resource_test.go:339: test for invalid configuration: mismatched-bucket-origin-type-and-params
    resource_test.go:339: test for invalid configuration: lacking-bucket-origin-params
    resource_test.go:339: test for invalid configuration: missing-logging-bucket-secret
    resource_test.go:339: test for invalid configuration: invalid-domain-type
    resource_test.go:339: test for invalid configuration: invalid-compression
    resource_test.go:339: test for invalid configuration: invalid-cors-configuration
    resource_test.go:339: test for invalid configuration: own-domain-without-domain
--- PASS: TestAccSakuraResourceWebAccel_InvalidConfigurations (51.80s)
=== RUN   TestAccImportSakuraWebAccel_WebOrigin
--- PASS: TestAccImportSakuraWebAccel_WebOrigin (7.68s)
=== RUN   TestAccImportSakuraWebAccel_BucketOrigin
--- PASS: TestAccImportSakuraWebAccel_BucketOrigin (7.54s)
```

</details>


### ドキュメントの変更は必要ですか？

不要