### PR TITLE
update monitoring-suite-api-go to fix #261

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/sacloud/iaas-service-go v1.25.0
 	github.com/sacloud/iam-api-go v0.3.0
 	github.com/sacloud/kms-api-go v0.4.0
-	github.com/sacloud/monitoring-suite-api-go v0.2.0
+	github.com/sacloud/monitoring-suite-api-go v0.2.1
 	github.com/sacloud/nosql-api-go v0.3.0
 	github.com/sacloud/object-storage-api-go v0.2.0
 	github.com/sacloud/packages-go v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/sacloud/iam-api-go v0.3.0 h1:t7dav2jRnn2DhSg5u9tpyoltFpastnTR/jNZ3OsW
 github.com/sacloud/iam-api-go v0.3.0/go.mod h1:uKYamf4LfU7gDkWS7MN2xFaiHr4g0DcAOGyr2fNSuL8=
 github.com/sacloud/kms-api-go v0.4.0 h1:F1/Cw7W2h6B/HWsoPDI7xMZkzFKphfVTBOHYh6DT2bM=
 github.com/sacloud/kms-api-go v0.4.0/go.mod h1:OSJD0mlzdZQXJPLbhBlAIthwxHISjWXhy9gHvUxieC0=
-github.com/sacloud/monitoring-suite-api-go v0.2.0 h1:xQzAoiXMwfW84nNK2ReATeppB+p5G1ktzapihm5vfnA=
-github.com/sacloud/monitoring-suite-api-go v0.2.0/go.mod h1:XaQbPe2EmBgtXGN5abwTJ1d9blMl6jA85695EhLwsoQ=
+github.com/sacloud/monitoring-suite-api-go v0.2.1 h1:C5H7/Kr5mId6+a6VxS1HpNu8zM0OR2kSxtAltYUlgtc=
+github.com/sacloud/monitoring-suite-api-go v0.2.1/go.mod h1:XaQbPe2EmBgtXGN5abwTJ1d9blMl6jA85695EhLwsoQ=
 github.com/sacloud/nosql-api-go v0.3.0 h1:pyrrldQerNsvEVdm+m9oZ3ao+y7a9SgCHaanOSvlNXo=
 github.com/sacloud/nosql-api-go v0.3.0/go.mod h1:A025O6HVlTJxRek7UlYAAcErFQr/Tqur36FEC4QBAqA=
 github.com/sacloud/object-storage-api-go v0.2.0 h1:PnGpPMrcDpVhJDNQhIfDVxPxqtpVk15Y+baixR2DAd4=

--- a/internal/service/monitoring_suite/resource_alert_notification_routing_test.go
+++ b/internal/service/monitoring_suite/resource_alert_notification_routing_test.go
@@ -61,6 +61,38 @@ func TestAccSakuraMonitoringSuiteAlertNotificationRouting_basic(t *testing.T) {
 	})
 }
 
+func TestAccSakuraMonitoringSuiteAlertNotificationRouting_emptyMatchLabels(t *testing.T) {
+	resourceName := "sakura_monitoring_suite_alert_notification_routing.foobar"
+	rand := test.RandomName()
+
+	var routing monitoringsuiteapi.NotificationRouting
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraMonitoringSuiteAlertNotificationRoutingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteAlertNotificationRouting_basicEmptyMatchLabels, rand),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraMonitoringSuiteAlertNotificationRoutingExists(resourceName, &routing),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "resend_interval_minutes", "10"),
+					resource.TestCheckResourceAttr(resourceName, "match_labels.#", "0"),
+				),
+			},
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteAlertNotificationRouting_updateEmptyMatchLabels, rand),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraMonitoringSuiteAlertNotificationRoutingExists(resourceName, &routing),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "resend_interval_minutes", "20"),
+					resource.TestCheckResourceAttr(resourceName, "match_labels.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckSakuraMonitoringSuiteAlertNotificationRoutingDestroy(s *terraform.State) error {
 	client := test.AccClientGetter()
 	op := monitoringsuite.NewNotificationRoutingOp(client.MonitoringSuiteClient)
@@ -164,3 +196,43 @@ resource "sakura_monitoring_suite_alert_notification_routing" "foobar" {
   ]
 }
 `
+
+var testAccSakuraMonitoringSuiteAlertNotificationRouting_basicEmptyMatchLabels = `
+resource "sakura_monitoring_suite_alert_project" "foobar" {
+  name = "{{ .arg0 }}"
+  description = "description"
+}
+
+resource "sakura_monitoring_suite_alert_notification_target" "foobar" {
+  alert_project_id = sakura_monitoring_suite_alert_project.foobar.id
+  service_type = "simple_notification"
+  url = "https://example.com/notify"
+  description = "notification-target"
+}
+
+resource "sakura_monitoring_suite_alert_notification_routing" "foobar" {
+  alert_project_id = sakura_monitoring_suite_alert_project.foobar.id
+  notification_target_id = sakura_monitoring_suite_alert_notification_target.foobar.id
+  resend_interval_minutes = 10
+  match_labels = []
+}`
+
+var testAccSakuraMonitoringSuiteAlertNotificationRouting_updateEmptyMatchLabels = `
+resource "sakura_monitoring_suite_alert_project" "foobar" {
+  name = "{{ .arg0 }}"
+  description = "description"
+}
+
+resource "sakura_monitoring_suite_alert_notification_target" "foobar" {
+  alert_project_id = sakura_monitoring_suite_alert_project.foobar.id
+  service_type = "simple_notification"
+  url = "https://example.com/notify"
+  description = "notification-target"
+}
+
+resource "sakura_monitoring_suite_alert_notification_routing" "foobar" {
+  alert_project_id = sakura_monitoring_suite_alert_project.foobar.id
+  notification_target_id = sakura_monitoring_suite_alert_notification_target.foobar.id
+  resend_interval_minutes = 20
+  match_labels = []
+}`


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #261

### このPRはどういう変更を行いますか？

monitoring-suite-api-goを更新することで空のmatch labelsを指定できない問題を修正する。

```
=== RUN   TestAccSakuraMonitoringSuiteAlertNotificationRouting_emptyMatchLabels
--- PASS: TestAccSakuraMonitoringSuiteAlertNotificationRouting_emptyMatchLabels (8.34s)
PASS
ok  	github.com/sacloud/terraform-provider-sakura/internal/service/monitoring_suite	8.924s
```

### ドキュメントの変更は必要ですか？

必要無し