### PR TITLE
deprecate: mark container_registry access_level as deprecated

### DIFF
--- a/docs/resources/container_registry.md
+++ b/docs/resources/container_registry.md
@@ -36,7 +36,6 @@ variable users {
 resource "sakura_container_registry" "foobar" {
   name            = "foobar"
   subdomain_label = "your-subdomain-label"
-  access_level    = "none" # this must be one of ["none"/"readonly"]
 
   description = "description"
   tags        = ["tag1", "tag2"]
@@ -57,12 +56,12 @@ resource "sakura_container_registry" "foobar" {
 
 ### Required
 
-- `access_level` (String) The level of access that allow to users. This must be one of [`readonly`/`none`]
 - `name` (String) The name of the Container Registry.
 - `subdomain_label` (String) The label at the lowest of the FQDN used when be accessed from users. The length of this value must be in the range [`1`-`64`]
 
 ### Optional
 
+- `access_level` (String, Deprecated) The level of access that allow to users. This must be one of [`readonly`/`none`]
 - `description` (String) The description of the Container Registry. The length of this value must be in the range [`1`-`512`]
 - `icon_id` (String) The icon id to attach to the Container Registry
 - `tags` (Set of String) The tags of the Container Registry.

--- a/examples/resources/sakura_container_registry/resource.tf
+++ b/examples/resources/sakura_container_registry/resource.tf
@@ -21,7 +21,6 @@ variable users {
 resource "sakura_container_registry" "foobar" {
   name            = "foobar"
   subdomain_label = "your-subdomain-label"
-  access_level    = "none" # this must be one of ["none"/"readonly"]
 
   description = "description"
   tags        = ["tag1", "tag2"]

--- a/internal/service/container_registry/resource.go
+++ b/internal/service/container_registry/resource.go
@@ -75,7 +75,11 @@ func (r *containerRegistryResource) Schema(ctx context.Context, req resource.Sch
 			"tags":        common.SchemaResourceTags("Container Registry"),
 			"icon_id":     common.SchemaResourceIconID("Container Registry"),
 			"access_level": schema.StringAttribute{
-				Required: true,
+				Optional:    true,
+				Computed:    true,
+				DeprecationMessage: "The \"access_level\" attribute is deprecated and will be removed in a future version. " +
+					"Public access settings for Container Registry are being discontinued. " +
+					"See: https://cloud.sakura.ad.jp/news/2026/05/27/container-registry-public-access-setting-discontinued/",
 				Description: desc.Sprintf(
 					"The level of access that allow to users. This must be one of [%s]",
 					iaastypes.ContainerRegistryAccessLevelStrings,
@@ -274,12 +278,17 @@ func (r *containerRegistryResource) Delete(ctx context.Context, req resource.Del
 }
 
 func expandContainerRegistryBuilder(d, config *containerRegistryResourceModel, c *common.APIClient, settingsHash string) *registryBuilder.Builder {
+	accessLevel := iaastypes.ContainerRegistryAccessLevels.None
+	if !d.AccessLevel.IsNull() && !d.AccessLevel.IsUnknown() {
+		accessLevel = iaastypes.EContainerRegistryAccessLevel(d.AccessLevel.ValueString())
+	}
+
 	return &registryBuilder.Builder{
 		Name:           d.Name.ValueString(),
 		Description:    d.Description.ValueString(),
 		Tags:           common.TsetToStrings(d.Tags),
 		IconID:         common.SakuraCloudID(d.IconID.ValueString()),
-		AccessLevel:    iaastypes.EContainerRegistryAccessLevel(d.AccessLevel.ValueString()),
+		AccessLevel:    accessLevel,
 		VirtualDomain:  d.VirtualDomain.ValueString(),
 		SubDomainLabel: d.SubDomainLabel.ValueString(),
 		Users:          expandContainerRegistryUsers(d.User, config.User),

--- a/internal/service/container_registry/resource.go
+++ b/internal/service/container_registry/resource.go
@@ -78,7 +78,7 @@ func (r *containerRegistryResource) Schema(ctx context.Context, req resource.Sch
 				Optional:    true,
 				Computed:    true,
 				DeprecationMessage: "The \"access_level\" attribute is deprecated and will be removed in a future version. " +
-					"Public access settings for Container Registry are being discontinued. " +
+					"Container Registry no longer supports public access settings. " +
 					"See: https://cloud.sakura.ad.jp/news/2026/05/27/container-registry-public-access-setting-discontinued/",
 				Description: desc.Sprintf(
 					"The level of access that allow to users. This must be one of [%s]",


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

sakura_container_registry の `access_level` 属性を非推奨にします。

- スキーマ上に `DeprecationMessage` を追加し、Terraform CLI が非推奨警告を出力するようにしました
- `Required: true` → `Optional: true, Computed: true` に変更し、未指定時はデフォルトで `"none"`（非公開）を使用するようにしました
- これにより、新規コードでは `access_level` を省略可能になり、既存コードでは移行を促す警告が表示されます
  - 既存のリソースでもあらかじめaccess_levelを消しておくことができ、将来のAPI廃止/フィールド削除に備えることができます
 

背景: コンテナレジストリの公開設定（Pullのみ）は廃止予定となり、今後は一律「非公開」での運用となります。
詳細: https://cloud.sakura.ad.jp/news/2026/05/27/container-registry-public-access-setting-discontinued/

### ドキュメントの変更は必要ですか？

不要。examples/ および docs/ は `make generate-docs` で自動生成済みです。


テスト結果:

```
=== RUN   TestAccSakuraDataSourceContainerRegistry_basic
--- PASS: TestAccSakuraDataSourceContainerRegistry_basic (12.30s)
=== RUN   TestAccSakuraContainerRegistry_basic
--- PASS: TestAccSakuraContainerRegistry_basic (15.69s)
=== RUN   TestAccSakuraContainerRegistry_WObasic
--- PASS: TestAccSakuraContainerRegistry_WObasic (12.17s)
=== RUN   TestAccImportSakuraContainerRegistry_basic
--- PASS: TestAccImportSakuraContainerRegistry_basic (11.66s)
PASS
ok      github.com/sacloud/terraform-provider-sakura/internal/service/container_registry        55.599s
```