### PR TITLE
Use OndemandDB hostname from state in plan

### DIFF
--- a/internal/service/enhanced_db/resource.go
+++ b/internal/service/enhanced_db/resource.go
@@ -119,6 +119,9 @@ func (r *enhancedDBResource) Schema(ctx context.Context, _ resource.SchemaReques
 			"hostname": schema.StringAttribute{
 				Computed:    true,
 				Description: "The name of database host. This will be built from `database_name` + `tidb-is1.db.sakurausercontent.com`",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"max_connections": schema.Int64Attribute{
 				Computed:    true,

--- a/internal/service/ondemand_db/resource.go
+++ b/internal/service/ondemand_db/resource.go
@@ -119,6 +119,9 @@ func (r *onDemandDBResource) Schema(ctx context.Context, _ resource.SchemaReques
 			"hostname": schema.StringAttribute{
 				Computed:    true,
 				Description: "The name of database host. This will be built from `database_name` + `tidb-is1.db.sakurausercontent.com`",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"max_connections": schema.Int64Attribute{
 				Computed:    true,


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### このPRはどういう変更を行いますか？

**解決する問題**：
オンデマンドDBのリソースにおいて、Plan時にフィールド更新がある場合、実際には変更されないが `hostname` も変更対象として計算される。`hostname` はアクセス先のFQDNに関わるので、DBを利用する多くのリソースが依存することが多い。
これにより、 `hostname` に依存する各種リソースが変更を予定するため、Plan時にのみ本来発生する変更よりも多くのリソースが変更予定として表示されてしまう。

**変更内容**：
`hostname`は、作成時に定まりその後再作成しない限り変更されない要素である。なので、`stringplanmodifier.UseStateForUnknown()` を用いて、作成後はstateから値を取得するように変更する。

### ドキュメントの変更は必要ですか？

不要