### PR TITLE
monitoring_suite: fix import of alert resources

### DIFF
--- a/docs/resources/monitoring_suite_alert_log_measure_rule.md
+++ b/docs/resources/monitoring_suite_alert_log_measure_rule.md
@@ -102,3 +102,14 @@ Optional:
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+# Specify the ID in the format of {alert_project_id}_{id}: e.g. "112345678901_123e4567-e89b-12d3-a456-426614174000"
+terraform import sakura_monitoring_suite_alert_log_measure_rule.foo '{alert_project_id}_{id}'
+```

--- a/docs/resources/monitoring_suite_alert_notification_routing.md
+++ b/docs/resources/monitoring_suite_alert_notification_routing.md
@@ -60,3 +60,14 @@ Optional:
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+# Specify the ID in the format of {alert_project_id}_{id}: e.g. "112345678901_123e4567-e89b-12d3-a456-426614174000"
+terraform import sakura_monitoring_suite_alert_notification_routing.foo '{alert_project_id}_{id}'
+```

--- a/docs/resources/monitoring_suite_alert_notification_target.md
+++ b/docs/resources/monitoring_suite_alert_notification_target.md
@@ -47,3 +47,14 @@ Optional:
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+# Specify the ID in the format of {alert_project_id}_{id}: e.g. "112345678901_123e4567-e89b-12d3-a456-426614174000"
+terraform import sakura_monitoring_suite_alert_notification_target.foo '{alert_project_id}_{id}'
+```

--- a/docs/resources/monitoring_suite_alert_rule.md
+++ b/docs/resources/monitoring_suite_alert_rule.md
@@ -62,3 +62,14 @@ Optional:
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+# Specify the ID in the format of {alert_project_id}_{id}: e.g. "112345678901_123e4567-e89b-12d3-a456-426614174000"
+terraform import sakura_monitoring_suite_alert_rule.foo '{alert_project_id}_{id}'
+```

--- a/examples/resources/sakura_monitoring_suite_alert_log_measure_rule/import.sh
+++ b/examples/resources/sakura_monitoring_suite_alert_log_measure_rule/import.sh
@@ -1,0 +1,2 @@
+# Specify the ID in the format of {alert_project_id}_{id}: e.g. "112345678901_123e4567-e89b-12d3-a456-426614174000"
+terraform import sakura_monitoring_suite_alert_log_measure_rule.foo '{alert_project_id}_{id}'

--- a/examples/resources/sakura_monitoring_suite_alert_notification_routing/import.sh
+++ b/examples/resources/sakura_monitoring_suite_alert_notification_routing/import.sh
@@ -1,0 +1,2 @@
+# Specify the ID in the format of {alert_project_id}_{id}: e.g. "112345678901_123e4567-e89b-12d3-a456-426614174000"
+terraform import sakura_monitoring_suite_alert_notification_routing.foo '{alert_project_id}_{id}'

--- a/examples/resources/sakura_monitoring_suite_alert_notification_target/import.sh
+++ b/examples/resources/sakura_monitoring_suite_alert_notification_target/import.sh
@@ -1,0 +1,2 @@
+# Specify the ID in the format of {alert_project_id}_{id}: e.g. "112345678901_123e4567-e89b-12d3-a456-426614174000"
+terraform import sakura_monitoring_suite_alert_notification_target.foo '{alert_project_id}_{id}'

--- a/examples/resources/sakura_monitoring_suite_alert_rule/import.sh
+++ b/examples/resources/sakura_monitoring_suite_alert_rule/import.sh
@@ -1,0 +1,2 @@
+# Specify the ID in the format of {alert_project_id}_{id}: e.g. "112345678901_123e4567-e89b-12d3-a456-426614174000"
+terraform import sakura_monitoring_suite_alert_rule.foo '{alert_project_id}_{id}'

--- a/internal/service/monitoring_suite/resource_alert_log_measure_rule.go
+++ b/internal/service/monitoring_suite/resource_alert_log_measure_rule.go
@@ -6,6 +6,7 @@ package monitoring_suite
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -108,7 +109,13 @@ func (r *alertLogMeasureRuleResource) Schema(ctx context.Context, _ resource.Sch
 }
 
 func (r *alertLogMeasureRuleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	parts := strings.SplitN(req.ID, "_", 2)
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError("Import: ID Format Error", "expected import ID format: <alert_project_id>_<uid>")
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alert_project_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
 }
 
 func (r *alertLogMeasureRuleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/service/monitoring_suite/resource_alert_log_measure_rule.go
+++ b/internal/service/monitoring_suite/resource_alert_log_measure_rule.go
@@ -111,7 +111,7 @@ func (r *alertLogMeasureRuleResource) Schema(ctx context.Context, _ resource.Sch
 func (r *alertLogMeasureRuleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	parts := strings.SplitN(req.ID, "_", 2)
 	if len(parts) != 2 {
-		resp.Diagnostics.AddError("Import: ID Format Error", "expected import ID format: <alert_project_id>_<uid>")
+		resp.Diagnostics.AddError("Import: ID Format Error", "expected import ID format: {alert_project_id}_{id}")
 		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alert_project_id"), parts[0])...)

--- a/internal/service/monitoring_suite/resource_alert_log_measure_rule_test.go
+++ b/internal/service/monitoring_suite/resource_alert_log_measure_rule_test.go
@@ -99,6 +99,61 @@ func TestAccSakuraMonitoringSuiteAlertLogMeasureRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccImportSakuraMonitoringSuiteAlertLogMeasureRule_basic(t *testing.T) {
+
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID", "SAKURA_MONITORING_SUITE_LOG_STORAGE_ID")
+
+	resourceName := "sakura_monitoring_suite_alert_log_measure_rule.foobar"
+	name := strings.ToLower(test.RandomName())
+	lsId := os.Getenv("SAKURA_MONITORING_SUITE_LOG_STORAGE_ID")
+	msId := os.Getenv("SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+		expects := map[string]string{
+			"name":              name,
+			"description":       "description",
+			"log_storage_id":    lsId,
+			"metric_storage_id": msId,
+			"rule.version":      "v1",
+		}
+
+		if err := test.CompareStateMulti(s[0], expects); err != nil {
+			return err
+		}
+		return test.StateNotEmptyMulti(s[0], "alert_project_id", "created_at", "updated_at", "id")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckSakuraMonitoringSuiteAlertLogMeasureRuleDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteAlertLogMeasureRule_basic, name, lsId, msId),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateCheck:        checkFn,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"rule.query.matchers"}, // matchersはjsonの比較でdiffが出る可能性があるため、import時の検証から除外する
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("resource not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s_%s", rs.Primary.Attributes["alert_project_id"], rs.Primary.Attributes["id"]), nil
+				},
+			},
+		},
+	})
+}
+
 func testCheckSakuraMonitoringSuiteAlertLogMeasureRuleDestroy(s *terraform.State) error {
 	client := test.AccClientGetter()
 	op := monitoringsuite.NewLogMeasureRuleOp(client.MonitoringSuiteClient)

--- a/internal/service/monitoring_suite/resource_alert_notification_routing.go
+++ b/internal/service/monitoring_suite/resource_alert_notification_routing.go
@@ -110,7 +110,7 @@ func (r *alertNotificationRoutingResource) Schema(ctx context.Context, _ resourc
 func (r *alertNotificationRoutingResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	parts := strings.SplitN(req.ID, "_", 2)
 	if len(parts) != 2 {
-		resp.Diagnostics.AddError("Import: ID Format Error", "expected import ID format: <alert_project_id>_<uid>")
+		resp.Diagnostics.AddError("Import: ID Format Error", "expected import ID format: {alert_project_id}_{id}")
 		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alert_project_id"), parts[0])...)

--- a/internal/service/monitoring_suite/resource_alert_notification_routing.go
+++ b/internal/service/monitoring_suite/resource_alert_notification_routing.go
@@ -6,6 +6,7 @@ package monitoring_suite
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -107,7 +108,13 @@ func (r *alertNotificationRoutingResource) Schema(ctx context.Context, _ resourc
 }
 
 func (r *alertNotificationRoutingResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	parts := strings.SplitN(req.ID, "_", 2)
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError("Import: ID Format Error", "expected import ID format: <alert_project_id>_<uid>")
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alert_project_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
 }
 
 func (r *alertNotificationRoutingResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/service/monitoring_suite/resource_alert_notification_routing_test.go
+++ b/internal/service/monitoring_suite/resource_alert_notification_routing_test.go
@@ -93,6 +93,54 @@ func TestAccSakuraMonitoringSuiteAlertNotificationRouting_emptyMatchLabels(t *te
 	})
 }
 
+func TestAccImportSakuraMonitoringSuiteAlertNotificationRouting_basic(t *testing.T) {
+	resourceName := "sakura_monitoring_suite_alert_notification_routing.foobar"
+	rand := test.RandomName()
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+		expects := map[string]string{
+			"resend_interval_minutes": "10",
+			"match_labels.#":          "1",
+			"match_labels.0.name":     "name1",
+			"match_labels.0.value":    "value1",
+		}
+
+		if err := test.CompareStateMulti(s[0], expects); err != nil {
+			return err
+		}
+		return test.StateNotEmptyMulti(s[0], "alert_project_id", "notification_target_id", "order")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckSakuraMonitoringSuiteAlertNotificationRoutingDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteAlertNotificationRouting_basic, rand),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateCheck:  checkFn,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("resource not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s_%s", rs.Primary.Attributes["alert_project_id"], rs.Primary.Attributes["id"]), nil
+				},
+			},
+		},
+	})
+}
+
 func testCheckSakuraMonitoringSuiteAlertNotificationRoutingDestroy(s *terraform.State) error {
 	client := test.AccClientGetter()
 	op := monitoringsuite.NewNotificationRoutingOp(client.MonitoringSuiteClient)

--- a/internal/service/monitoring_suite/resource_alert_notification_target.go
+++ b/internal/service/monitoring_suite/resource_alert_notification_target.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -90,7 +91,13 @@ func (r *alertNotificationTargetResource) Schema(ctx context.Context, _ resource
 }
 
 func (r *alertNotificationTargetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	parts := strings.SplitN(req.ID, "_", 2)
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError("Import: ID Format Error", "expected import ID format: <alert_project_id>_<uid>")
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alert_project_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
 }
 
 func (r *alertNotificationTargetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/service/monitoring_suite/resource_alert_notification_target.go
+++ b/internal/service/monitoring_suite/resource_alert_notification_target.go
@@ -93,7 +93,7 @@ func (r *alertNotificationTargetResource) Schema(ctx context.Context, _ resource
 func (r *alertNotificationTargetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	parts := strings.SplitN(req.ID, "_", 2)
 	if len(parts) != 2 {
-		resp.Diagnostics.AddError("Import: ID Format Error", "expected import ID format: <alert_project_id>_<uid>")
+		resp.Diagnostics.AddError("Import: ID Format Error", "expected import ID format: {alert_project_id}_{id}")
 		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alert_project_id"), parts[0])...)
@@ -117,7 +117,7 @@ func (r *alertNotificationTargetResource) Create(ctx context.Context, req resour
 		URL:         expandNotificationTargetURL(plan.URL.ValueString()),
 	})
 	if err != nil {
-		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to create Alert Project: %s", err))
+		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to create Alert Notification Target: %s", err))
 		return
 	}
 

--- a/internal/service/monitoring_suite/resource_alert_notification_target_test.go
+++ b/internal/service/monitoring_suite/resource_alert_notification_target_test.go
@@ -55,6 +55,53 @@ func TestAccSakuraMonitoringSuiteAlertNotificationTarget_basic(t *testing.T) {
 	})
 }
 
+func TestAccImportSakuraMonitoringSuiteAlertNotificationTarget_basic(t *testing.T) {
+	resourceName := "sakura_monitoring_suite_alert_notification_target.foobar"
+	rand := test.RandomName()
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+		expects := map[string]string{
+			"service_type": "simple_notification",
+			"url":          "https://example.com/notify",
+			"description":  "notification-target",
+		}
+
+		if err := test.CompareStateMulti(s[0], expects); err != nil {
+			return err
+		}
+		return test.StateNotEmptyMulti(s[0], "config")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckSakuraMonitoringSuiteAlertNotificationTargetDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteAlertNotificationTarget_basic, rand),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateCheck:  checkFn,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("resource not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s_%s", rs.Primary.Attributes["alert_project_id"], rs.Primary.Attributes["id"]), nil
+				},
+			},
+		},
+	})
+}
+
 func testCheckSakuraMonitoringSuiteAlertNotificationTargetDestroy(s *terraform.State) error {
 	client := test.AccClientGetter()
 	op := monitoringsuite.NewNotificationTargetOp(client.MonitoringSuiteClient)

--- a/internal/service/monitoring_suite/resource_alert_rule.go
+++ b/internal/service/monitoring_suite/resource_alert_rule.go
@@ -6,6 +6,7 @@ package monitoring_suite
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -131,7 +132,13 @@ func (r *alertRuleResource) Schema(ctx context.Context, _ resource.SchemaRequest
 }
 
 func (r *alertRuleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	parts := strings.SplitN(req.ID, "_", 2)
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError("Import: ID Format Error", "expected import ID format: <alert_project_id>_<uid>")
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alert_project_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
 }
 
 func (r *alertRuleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/service/monitoring_suite/resource_alert_rule.go
+++ b/internal/service/monitoring_suite/resource_alert_rule.go
@@ -134,7 +134,7 @@ func (r *alertRuleResource) Schema(ctx context.Context, _ resource.SchemaRequest
 func (r *alertRuleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	parts := strings.SplitN(req.ID, "_", 2)
 	if len(parts) != 2 {
-		resp.Diagnostics.AddError("Import: ID Format Error", "expected import ID format: <alert_project_id>_<uid>")
+		resp.Diagnostics.AddError("Import: ID Format Error", "expected import ID format: {alert_project_id}_{id}")
 		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("alert_project_id"), parts[0])...)
@@ -166,7 +166,7 @@ func (r *alertRuleResource) Create(ctx context.Context, req resource.CreateReque
 		ThresholdDurationCritical: expandOptionalInt64(plan.ThresholdDurationCritical),
 	})
 	if err != nil {
-		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to create Alert Project: %s", err))
+		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to create Alert Rule: %s", err))
 		return
 	}
 

--- a/internal/service/monitoring_suite/resource_alert_rule_test.go
+++ b/internal/service/monitoring_suite/resource_alert_rule_test.go
@@ -71,6 +71,62 @@ func TestAccSakuraMonitoringSuiteAlertRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccImportSakuraMonitoringSuiteAlertRule_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
+
+	resourceName := "sakura_monitoring_suite_alert_rule.foobar"
+	rand := test.RandomName()
+	sId := os.Getenv("SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+		expects := map[string]string{
+			"name":                        rand,
+			"metric_storage_id":           sId,
+			"query":                       "count_values",
+			"enabled_warning":             "true",
+			"enabled_critical":            "true",
+			"threshold_warning":           ">=10",
+			"threshold_critical":          ">=20",
+			"threshold_duration_warning":  "600",
+			"threshold_duration_critical": "600",
+		}
+
+		if err := test.CompareStateMulti(s[0], expects); err != nil {
+			return err
+		}
+		return test.StateNotEmptyMulti(s[0], "open")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckSakuraMonitoringSuiteAlertRuleDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteAlertRule_basic, rand, sId),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateCheck:  checkFn,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("resource not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s_%s", rs.Primary.Attributes["alert_project_id"], rs.Primary.Attributes["id"]), nil
+				},
+			},
+		},
+	})
+}
+
 func testCheckSakuraMonitoringSuiteAlertRuleDestroy(s *terraform.State) error {
 	client := test.AccClientGetter()
 	op := monitoringsuite.NewAlertRuleOp(client.MonitoringSuiteClient)


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #266 

### このPRはどういう変更を行いますか？

モニタリングスイートのアラート関係のリソースのimportを修正し、テストを追加。

テスト結果
```
% TF_ACC=1 go test ./internal/service/monitoring_suite -timeout=200m -v -run TestAccImportSakuraMonitoringSuiteAlert             (git)-[main]
=== RUN   TestAccImportSakuraMonitoringSuiteAlertLogMeasureRule_basic
--- PASS: TestAccImportSakuraMonitoringSuiteAlertLogMeasureRule_basic (4.63s)
=== RUN   TestAccImportSakuraMonitoringSuiteAlertNotificationRouting_basic
--- PASS: TestAccImportSakuraMonitoringSuiteAlertNotificationRouting_basic (5.39s)
=== RUN   TestAccImportSakuraMonitoringSuiteAlertNotificationTarget_basic
--- PASS: TestAccImportSakuraMonitoringSuiteAlertNotificationTarget_basic (4.12s)
=== RUN   TestAccImportSakuraMonitoringSuiteAlertRule_basic
--- PASS: TestAccImportSakuraMonitoringSuiteAlertRule_basic (4.29s)
PASS
ok  	github.com/sacloud/terraform-provider-sakura/internal/service/monitoring_suite	19.018s
```

### ドキュメントの変更は必要ですか？

importにアラートプロジェクトのIDが必要なので例を追加する