### PR TITLE
docs: announce v2 end-of-maintenance and update migration notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## terraform-plugin-frameworkによる書き換え
 
-現在リリースされているv2はSDK v2を利用していますが、v3はFrameworkを利用しています。
+v2はSDK v2を利用していましたが、v3はFrameworkを利用しています。
 muxなどの互換レイヤーも使っておらず、完全移行となります。
 
 ## 命名の変更

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Terraform 自体については [Terraform の公式ドキュメント](https://
 
 ## v2 からのマイグレーション
 
-[Terraform Provider for さくらのクラウド v2](https://github.com/sacloud/terraform-provider-sakuracloud) と *Terraform Provider for さくらのクラウド v3* には
-互換性がありません。
+> [!IMPORTANT]
+> [Terraform Provider for さくらのクラウド v2](https://github.com/sacloud/terraform-provider-sakuracloud) は **2026年12月末をもってメンテナンスを終了**します。
+> 詳細は [Terraform Provider v2 メンテナンス終了のお知らせ](https://cloud.sakura.ad.jp/news/2026/06/23/terraform-provider-v2-end-of-maintenance/) をご覧ください。
 
+v2 と *Terraform Provider for さくらのクラウド v3* には互換性がありません。  
 v3 における変更点は [CHANGES.md](./CHANGES.md) をご覧ください。
 
 ## v3 のリソース対応状況
@@ -27,7 +29,9 @@ v3 における変更点は [CHANGES.md](./CHANGES.md) をご覧ください。
 
 ### v2からの移植
 
-以下のリソースは未移植です。必要な場合はv2との併用を検討してください。
+> [!IMPORTANT]
+> 以下のリソースは v3 では未移植です。これらを利用している場合は、v3 への移行にあたってそれらのリソースをどう扱うかを検討してください。  
+> 例えば、コントロールパネルや API など別の方法で管理する、またはリスクを踏まえたうえで v2 を一時的に利用し続けるなどを検討してください。
 
 - archive_share
 - certificate_authority


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

Terraform Provider v2 のメンテナンス終了（2026年12月末）に伴い、リポジトリ内のドキュメントを更新しました。

- README.md: v2 のメンテナンス終了を GitHub アラート記法で明記し、未移植リソースへの対応方針を修正
- CHANGES.md: v2 に関する時制を修正

### ドキュメントの変更は必要ですか？

本PRがドキュメント変更そのものです。

<!-- for GitHub Copilot: レビューは日本語で実施してください -->