### PR TITLE
apprun_dedicated: fix nil pointer panic

### DIFF
--- a/docs/resources/apprun_dedicated_version.md
+++ b/docs/resources/apprun_dedicated_version.md
@@ -86,11 +86,11 @@ Optional:
 
 Required:
 
-- `health_check` (Attributes) Health check configuration (see [below for nested schema](#nestedatt--exposed_ports--health_check))
 - `target_port` (Number) The port that the application listens to
 
 Optional:
 
+- `health_check` (Attributes) Health check configuration (see [below for nested schema](#nestedatt--exposed_ports--health_check))
 - `host` (Set of String) Target `Host:` header value (only applicable when `http` or `https`)
 - `lb_port` (Number) The port that the load balancer listens to.  Explicitly set it to `null` when you want to disconnect from the load balancer
 - `use_lets_encrypt` (Boolean) Whether the load balancer uses Let's Encrypt (applicable only when `https`)

--- a/internal/service/apprun_dedicated/model_version.go
+++ b/internal/service/apprun_dedicated/model_version.go
@@ -129,7 +129,10 @@ func (p exposedPortModel) intoCreate() (ret version.ExposedPort, diag diag.Diagn
 	ret.TargetPort = v1.Port(p.TargetPort.ValueInt32())
 	ret.UseLetsEncrypt = p.UseLetsEncrypt.ValueBool()
 	ret.Host = common.TsetToStrings(p.Host)
-	ret.HealthCheck = saclient.Ptr(p.HealthCheck.intoCreate())
+
+	if p.HealthCheck != nil {
+		ret.HealthCheck = saclient.Ptr(p.HealthCheck.intoCreate())
+	}
 
 	var port *uint16
 	switch {
@@ -179,6 +182,12 @@ func (p *exposedPortModel) updateState(d version.ExposedPort) {
 	p.LoadBalancerPort = p.int32(d.LoadBalancerPort)
 	p.UseLetsEncrypt = types.BoolValue(d.UseLetsEncrypt)
 	p.Host = common.StringsToTset(d.Host)
+
+	if d.HealthCheck == nil {
+		p.HealthCheck = nil
+		return
+	}
+
 	p.HealthCheck = new(healthCheckModel)
 	p.HealthCheck.updateState(d.HealthCheck)
 }

--- a/internal/service/apprun_dedicated/model_version_test.go
+++ b/internal/service/apprun_dedicated/model_version_test.go
@@ -23,6 +23,33 @@ func TestExposedPortModelUpdateStateNilHealthCheck(t *testing.T) {
 	}
 }
 
+// A configured health_check is mapped into every field on read.
+func TestExposedPortModelUpdateStateWithHealthCheck(t *testing.T) {
+	var p exposedPortModel
+
+	p.updateState(version.ExposedPort{
+		TargetPort: v1.Port(80),
+		HealthCheck: &v1.HealthCheck{
+			Path:            "/healthz",
+			IntervalSeconds: 10,
+			TimeoutSeconds:  5,
+		},
+	})
+
+	if p.HealthCheck == nil {
+		t.Fatal("HealthCheck should be populated when the API returns it")
+	}
+	if got := p.HealthCheck.Path.ValueString(); got != "/healthz" {
+		t.Fatalf("Path = %q, want %q", got, "/healthz")
+	}
+	if got := p.HealthCheck.IntervalSeconds.ValueInt32(); got != 10 {
+		t.Fatalf("IntervalSeconds = %d, want 10", got)
+	}
+	if got := p.HealthCheck.TimeoutSeconds.ValueInt32(); got != 5 {
+		t.Fatalf("TimeoutSeconds = %d, want 5", got)
+	}
+}
+
 // health_check is optional, so an omitted block must not panic on create.
 func TestExposedPortModelIntoCreateNilHealthCheck(t *testing.T) {
 	p := exposedPortModel{TargetPort: types.Int32Value(80)}

--- a/internal/service/apprun_dedicated/model_version_test.go
+++ b/internal/service/apprun_dedicated/model_version_test.go
@@ -1,0 +1,37 @@
+// Copyright 2016-2026 The terraform-provider-sakura Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package apprun_dedicated
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	v1 "github.com/sacloud/apprun-dedicated-api-go/apis/v1"
+	"github.com/sacloud/apprun-dedicated-api-go/apis/version"
+)
+
+// Regression: reading a port whose health_check is not configured panicked because
+// the API returns ExposedPort.HealthCheck=nil and updateState dereferenced it.
+func TestExposedPortModelUpdateStateNilHealthCheck(t *testing.T) {
+	var p exposedPortModel
+
+	p.updateState(version.ExposedPort{TargetPort: v1.Port(80), HealthCheck: nil}) // must not panic
+
+	if p.HealthCheck != nil {
+		t.Fatalf("HealthCheck should stay null when the API returns nil, got %+v", p.HealthCheck)
+	}
+}
+
+// health_check is optional, so an omitted block must not panic on create.
+func TestExposedPortModelIntoCreateNilHealthCheck(t *testing.T) {
+	p := exposedPortModel{TargetPort: types.Int32Value(80)}
+
+	got, diags := p.intoCreate()
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if got.HealthCheck != nil {
+		t.Fatalf("HealthCheck should be nil when omitted, got %+v", got.HealthCheck)
+	}
+}

--- a/internal/service/apprun_dedicated/resource_application_test.go
+++ b/internal/service/apprun_dedicated/resource_application_test.go
@@ -142,13 +142,8 @@ resource "sakura_apprun_dedicated_version" "main" {
 
   exposed_ports = [
     {
-      target_port        = 80
-	  lb_port            = null
-      health_check       = {
-        path             = "/"
-        interval_seconds = 10
-        timeout_seconds  = 5
-      }
+      target_port = 80
+      lb_port     = null
     }
   ]
 }
@@ -171,13 +166,8 @@ resource "sakura_apprun_dedicated_version" "main" {
 
   exposed_ports = [
     {
-      target_port        = 80
-	  lb_port            = null
-      health_check       = {
-        path             = "/"
-        interval_seconds = 10
-        timeout_seconds  = 5
-      }
+      target_port = 80
+      lb_port     = null
     }
   ]
 }
@@ -200,13 +190,8 @@ resource "sakura_apprun_dedicated_version" "main" {
 
   exposed_ports = [
     {
-      target_port        = 80
-	  lb_port            = null
-      health_check       = {
-        path             = "/"
-        interval_seconds = 10
-        timeout_seconds  = 5
-      }
+      target_port = 80
+      lb_port     = null
     }
   ]
 }

--- a/internal/service/apprun_dedicated/resource_application_test.go
+++ b/internal/service/apprun_dedicated/resource_application_test.go
@@ -144,6 +144,11 @@ resource "sakura_apprun_dedicated_version" "main" {
     {
       target_port = 80
       lb_port     = null
+      health_check = {
+        path             = "/"
+        interval_seconds = 10
+        timeout_seconds  = 5
+      }
     }
   ]
 }
@@ -168,6 +173,11 @@ resource "sakura_apprun_dedicated_version" "main" {
     {
       target_port = 80
       lb_port     = null
+      health_check = {
+        path             = "/"
+        interval_seconds = 10
+        timeout_seconds  = 5
+      }
     }
   ]
 }
@@ -192,6 +202,11 @@ resource "sakura_apprun_dedicated_version" "main" {
     {
       target_port = 80
       lb_port     = null
+      health_check = {
+        path             = "/"
+        interval_seconds = 10
+        timeout_seconds  = 5
+      }
     }
   ]
 }

--- a/internal/service/apprun_dedicated/resource_application_test.go
+++ b/internal/service/apprun_dedicated/resource_application_test.go
@@ -142,9 +142,9 @@ resource "sakura_apprun_dedicated_version" "main" {
 
   exposed_ports = [
     {
-      target_port = 80
-      lb_port     = null
-      health_check = {
+      target_port        = 80
+	  lb_port            = null
+      health_check       = {
         path             = "/"
         interval_seconds = 10
         timeout_seconds  = 5
@@ -171,9 +171,9 @@ resource "sakura_apprun_dedicated_version" "main" {
 
   exposed_ports = [
     {
-      target_port = 80
-      lb_port     = null
-      health_check = {
+      target_port        = 80
+	  lb_port            = null
+      health_check       = {
         path             = "/"
         interval_seconds = 10
         timeout_seconds  = 5
@@ -200,9 +200,9 @@ resource "sakura_apprun_dedicated_version" "main" {
 
   exposed_ports = [
     {
-      target_port = 80
-      lb_port     = null
-      health_check = {
+      target_port        = 80
+	  lb_port            = null
+      health_check       = {
         path             = "/"
         interval_seconds = 10
         timeout_seconds  = 5

--- a/internal/service/apprun_dedicated/resource_version.go
+++ b/internal/service/apprun_dedicated/resource_version.go
@@ -203,7 +203,7 @@ func (r *verResource) Schema(ctx context.Context, _ resource.SchemaRequest, res 
 							PlanModifiers:       []planmodifier.Set{setplanmodifier.RequiresReplace()},
 						},
 						"health_check": schema.SingleNestedAttribute{
-							Required:    true,
+							Optional:    true,
 							Description: "Health check configuration",
 							Attributes: map[string]schema.Attribute{
 								"path": schema.StringAttribute{

--- a/internal/service/apprun_dedicated/resource_version_test.go
+++ b/internal/service/apprun_dedicated/resource_version_test.go
@@ -91,8 +91,6 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 		})
 	})
 
-	// Regression for the nil pointer panic: a port whose health_check is omitted is
-	// read back with HealthCheck=nil and must not crash the provider.
 	t.Run("without_health_check", func(t *testing.T) {
 		resourceName := "sakura_apprun_dedicated_version.main"
 		name := acctest.RandStringFromCharSet(14, acctest.CharSetAlphaNum)
@@ -175,8 +173,8 @@ resource "sakura_apprun_dedicated_version" "main" {
 
   exposed_ports = [
     {
-      target_port = 80
-      lb_port     = null
+      target_port  = 80
+      lb_port      = null
       health_check = {
         path             = "/"
         interval_seconds = 10

--- a/internal/service/apprun_dedicated/resource_version_test.go
+++ b/internal/service/apprun_dedicated/resource_version_test.go
@@ -49,7 +49,11 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 								"lb_port":          knownvalue.Null(),
 								"use_lets_encrypt": knownvalue.Bool(false),
 								"host":             knownvalue.Null(),
-								"health_check":     knownvalue.Null(),
+								"health_check": knownvalue.ObjectExact(map[string]knownvalue.Check{
+									"path":             knownvalue.StringExact("/"),
+									"interval_seconds": knownvalue.Int32Exact(10),
+									"timeout_seconds":  knownvalue.Int32Exact(5),
+								}),
 							}),
 						})),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("env_vars"), knownvalue.ListExact([]knownvalue.Check{
@@ -81,6 +85,35 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 						appID := rs.Primary.Attributes["application_id"]
 						version := rs.Primary.Attributes["version"]
 						return fmt.Sprintf("%s/%s", appID, version), nil
+					},
+				},
+			},
+		})
+	})
+
+	// Regression for the nil pointer panic: a port whose health_check is omitted is
+	// read back with HealthCheck=nil and must not crash the provider.
+	t.Run("without_health_check", func(t *testing.T) {
+		resourceName := "sakura_apprun_dedicated_version.main"
+		name := acctest.RandStringFromCharSet(14, acctest.CharSetAlphaNum)
+
+		resource.ParallelTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+			PreCheck:                 AccPreCheck(t),
+			CheckDestroy:             testCheckSakuraApprunDedicatedVersionDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: test.BuildConfigWithArgs(testAccSakuraResourceApprunDedicatedVersion_noHealthCheck, name, globalClusterID),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("exposed_ports"), knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"target_port":      knownvalue.Int32Exact(80),
+								"lb_port":          knownvalue.Null(),
+								"use_lets_encrypt": knownvalue.Bool(false),
+								"host":             knownvalue.Null(),
+								"health_check":     knownvalue.Null(),
+							}),
+						})),
 					},
 				},
 			},
@@ -144,7 +177,11 @@ resource "sakura_apprun_dedicated_version" "main" {
     {
       target_port = 80
       lb_port     = null
-      # health_check is optional and omitted here.
+      health_check = {
+        path             = "/"
+        interval_seconds = 10
+        timeout_seconds  = 5
+      }
     }
   ]
 
@@ -158,6 +195,30 @@ resource "sakura_apprun_dedicated_version" "main" {
       key    = "ENV_VAR2"
       value  = "value2"
       secret = true
+    }
+  ]
+}
+`
+
+var testAccSakuraResourceApprunDedicatedVersion_noHealthCheck = `
+resource "sakura_apprun_dedicated_application" "main" {
+  cluster_id     = "{{ .arg1 }}"
+  name           = "tfacc-{{ .arg0 }}"
+  active_version = null
+}
+
+resource "sakura_apprun_dedicated_version" "main" {
+  application_id = sakura_apprun_dedicated_application.main.id
+  cpu            = 100
+  memory         = 256
+  scaling_mode   = "manual"
+  fixed_scale    = 1
+  image          = "nginx:latest"
+
+  exposed_ports = [
+    {
+      target_port = 80
+      lb_port     = null
     }
   ]
 }

--- a/internal/service/apprun_dedicated/resource_version_test.go
+++ b/internal/service/apprun_dedicated/resource_version_test.go
@@ -49,11 +49,7 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 								"lb_port":          knownvalue.Null(),
 								"use_lets_encrypt": knownvalue.Bool(false),
 								"host":             knownvalue.Null(),
-								"health_check": knownvalue.ObjectExact(map[string]knownvalue.Check{
-									"path":             knownvalue.StringExact("/"),
-									"interval_seconds": knownvalue.Int32Exact(10),
-									"timeout_seconds":  knownvalue.Int32Exact(5),
-								}),
+								"health_check":     knownvalue.Null(),
 							}),
 						})),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("env_vars"), knownvalue.ListExact([]knownvalue.Check{
@@ -146,13 +142,9 @@ resource "sakura_apprun_dedicated_version" "main" {
 
   exposed_ports = [
     {
-      target_port  = 80
-      lb_port      = null
-      health_check = {
-        path             = "/"
-        interval_seconds = 10
-        timeout_seconds  = 5
-      }
+      target_port = 80
+      lb_port     = null
+      # health_check is optional and omitted here.
     }
   ]
 

--- a/internal/service/apprun_dedicated/resource_version_test.go
+++ b/internal/service/apprun_dedicated/resource_version_test.go
@@ -114,6 +114,21 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 						})),
 					},
 				},
+				{
+					ResourceName:            resourceName,
+					ImportState:             true,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"timeouts", "registry_password"},
+					ImportStateIdFunc: func(s *terraform.State) (string, error) {
+						rs, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return "", fmt.Errorf("not found: %s", resourceName)
+						}
+						appID := rs.Primary.Attributes["application_id"]
+						version := rs.Primary.Attributes["version"]
+						return fmt.Sprintf("%s/%s", appID, version), nil
+					},
+				},
 			},
 		})
 	})


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes https://github.com/sacloud/terraform-provider-sakura/issues/273  

### このPRはどういう変更を行いますか？
・Read 経路の nil ガード（resource + data source 両方） ← クラッシュの直接原因の修正
・health_check の Optional 化
・Create 経路の nil ガード（Optional 化に伴う省略時の防御）
・テストの追加
  
### ドキュメントの変更は必要ですか？
レビュー後ドキュメントを生成。