### PR TITLE
test: remove access_level from container_registry tests

### DIFF
--- a/internal/service/container_registry/data_source_test.go
+++ b/internal/service/container_registry/data_source_test.go
@@ -27,7 +27,6 @@ func TestAccSakuraDataSourceContainerRegistry_basic(t *testing.T) {
 					test.CheckSakuraDataSourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rand),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
-					resource.TestCheckResourceAttr(resourceName, "access_level", "none"),
 					resource.TestCheckResourceAttr(resourceName, "user.#", "2"),
 					/* 現状userのレスポンスはユーザが登録された順とは確定していないため、順番に依存するテストは一旦コメントアウト
 					resource.TestCheckResourceAttr(resourceName, "user.0.name", "user1"),
@@ -45,7 +44,6 @@ var testAccSakuraDataSourceContainerRegistry_basic = `
 resource "sakura_container_registry" "foobar" {
   name            = "{{ .arg0 }}"
   subdomain_label = "{{ .arg1 }}"
-  access_level    = "none"
 
   description = "description"
   tags        = ["tag1", "tag2"]

--- a/internal/service/container_registry/resource_test.go
+++ b/internal/service/container_registry/resource_test.go
@@ -40,7 +40,6 @@ func TestAccSakuraContainerRegistry_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
 					resource.TestCheckResourceAttr(resourceName, "virtual_domain", subDomainLabel+".usacloud.jp"),
 					resource.TestCheckResourceAttr(resourceName, "fqdn", subDomainLabel+".sakuracr.jp"),
-					resource.TestCheckResourceAttr(resourceName, "access_level", "readonly"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1"),
@@ -66,7 +65,6 @@ func TestAccSakuraContainerRegistry_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
 					resource.TestCheckResourceAttr(resourceName, "virtual_domain", subDomainLabel+"-upd.usacloud.jp"),
 					resource.TestCheckResourceAttr(resourceName, "fqdn", subDomainLabel+".sakuracr.jp"),
-					resource.TestCheckResourceAttr(resourceName, "access_level", "none"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description-upd"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1-upd"),
@@ -105,7 +103,6 @@ func TestAccSakuraContainerRegistry_WObasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
 					resource.TestCheckResourceAttr(resourceName, "virtual_domain", subDomainLabel+".usacloud.jp"),
 					resource.TestCheckResourceAttr(resourceName, "fqdn", subDomainLabel+".sakuracr.jp"),
-					resource.TestCheckResourceAttr(resourceName, "access_level", "none"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1"),
@@ -131,7 +128,6 @@ func TestAccSakuraContainerRegistry_WObasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "subdomain_label", subDomainLabel),
 					resource.TestCheckResourceAttr(resourceName, "virtual_domain", subDomainLabel+"-upd.usacloud.jp"),
 					resource.TestCheckResourceAttr(resourceName, "fqdn", subDomainLabel+".sakuracr.jp"),
-					resource.TestCheckResourceAttr(resourceName, "access_level", "none"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description-upd"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "tag1-upd"),
@@ -233,7 +229,6 @@ resource "sakura_container_registry" "foobar" {
   name            = "{{ .arg0 }}"
   virtual_domain  = "{{ .arg1 }}.usacloud.jp"
   subdomain_label = "{{ .arg1 }}"
-  access_level    = "readonly"
 
   description = "description"
   tags        = ["tag1", "tag2"]
@@ -262,7 +257,6 @@ resource "sakura_container_registry" "foobar" {
   name            = "{{ .arg0 }}-upd"
   virtual_domain  = "{{ .arg1 }}-upd.usacloud.jp"
   subdomain_label = "{{ .arg1 }}"
-  access_level    = "none"
 
   description = "description-upd"
   tags        = ["tag1-upd", "tag2-upd"]
@@ -280,7 +274,6 @@ resource "sakura_container_registry" "foobar" {
   name            = "{{ .arg0 }}"
   virtual_domain  = "{{ .arg1 }}.usacloud.jp"
   subdomain_label = "{{ .arg1 }}"
-  access_level    = "none"
 
   description = "description"
   tags        = ["tag1", "tag2"]
@@ -305,7 +298,6 @@ resource "sakura_container_registry" "foobar" {
   name            = "{{ .arg0 }}-upd"
   virtual_domain  = "{{ .arg1 }}-upd.usacloud.jp"
   subdomain_label = "{{ .arg1 }}"
-  access_level    = "none"
 
   description = "description-upd"
   tags        = ["tag1-upd", "tag2-upd"]
@@ -324,7 +316,6 @@ resource "sakura_container_registry" "foobar" {
   name            = "{{ .arg0 }}"
   virtual_domain  = "{{ .arg1 }}.usacloud.jp"
   subdomain_label = "{{ .arg1 }}"
-  access_level    = "readonly"
 
   description = "description"
   tags        = ["tag1", "tag2"]


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

関連PR: https://github.com/sacloud/terraform-provider-sakura/pull/264

### このPRはどういう変更を行いますか？

Container Registry の公開アクセス設定 (`access_level`) はサービス側で `none` 以外が作成できなくなっており、最終的な廃止日も決定している。
参考: https://cloud.sakura.ad.jp/news/2026/05/27/container-registry-public-access-setting-discontinued/

`readonly` を指定している既存ユーザーは現時点で引き続き動作するが、今後減少していく見込みであるため、この段階で受け入れテストから `access_level` に関する記述を削除する。

- `access_level` のアサーションを削除
- `access_level` を含む HCL 設定を削除

プロバイダー側の実装やドキュメントは変更しておらず、既存ユーザーへの影響はない。

テスト結果:

```
=== RUN   TestAccSakuraDataSourceContainerRegistry_basic
--- PASS: TestAccSakuraDataSourceContainerRegistry_basic (17.42s)
=== RUN   TestAccSakuraContainerRegistry_basic
--- PASS: TestAccSakuraContainerRegistry_basic (18.23s)
=== RUN   TestAccSakuraContainerRegistry_WObasic
--- PASS: TestAccSakuraContainerRegistry_WObasic (14.51s)
=== RUN   TestAccImportSakuraContainerRegistry_basic
--- PASS: TestAccImportSakuraContainerRegistry_basic (13.27s)
PASS
ok      github.com/sacloud/terraform-provider-sakura/internal/service/container_registry        67.630s
```


### ドキュメントの変更は必要ですか？

不要