### PR TITLE
monitoring_suite: use pre-created storage to reduce resource consumption in test

### DIFF
--- a/internal/service/monitoring_suite/data_source_log_storage_test.go
+++ b/internal/service/monitoring_suite/data_source_log_storage_test.go
@@ -4,6 +4,7 @@
 package monitoring_suite_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -11,18 +12,20 @@ import (
 )
 
 func TestAccSakuraMonitoringSuiteLogStorageDataSource_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_LOG_STORAGE_ID")
+
 	resourceName := "data.sakura_monitoring_suite_log_storage.foobar"
-	rand := test.RandomName()
+	id := os.Getenv("SAKURA_MONITORING_SUITE_LOG_STORAGE_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteLogStorageDataSource_basic, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteLogStorageDataSource_basic, id),
 				Check: resource.ComposeTestCheckFunc(
 					test.CheckSakuraDataSourceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf-test"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
 					resource.TestCheckResourceAttr(resourceName, "classification", "shared"),
 					resource.TestCheckResourceAttr(resourceName, "is_system", "false"),
@@ -39,14 +42,7 @@ func TestAccSakuraMonitoringSuiteLogStorageDataSource_basic(t *testing.T) {
 }
 
 var testAccSakuraMonitoringSuiteLogStorageDataSource_basic = `
-resource "sakura_monitoring_suite_log_storage" "foobar" {
-  name = "{{ .arg0 }}"
-  description = "description"
-  classification = "shared"
-  is_system = false
-}
-
 data "sakura_monitoring_suite_log_storage" "foobar" {
-  id = sakura_monitoring_suite_log_storage.foobar.id
+  id = "{{ .arg0 }}"
 }
 `

--- a/internal/service/monitoring_suite/data_source_metric_storage_test.go
+++ b/internal/service/monitoring_suite/data_source_metric_storage_test.go
@@ -4,6 +4,7 @@
 package monitoring_suite_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -11,18 +12,20 @@ import (
 )
 
 func TestAccSakuraMonitoringSuiteMetricStorageDataSource_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
+
 	resourceName := "data.sakura_monitoring_suite_metric_storage.foobar"
-	rand := test.RandomName()
+	id := os.Getenv("SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteMetricStorageDataSource_basic, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteMetricStorageDataSource_basic, id),
 				Check: resource.ComposeTestCheckFunc(
 					test.CheckSakuraDataSourceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf-test"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
 					resource.TestCheckResourceAttr(resourceName, "is_system", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
@@ -37,13 +40,7 @@ func TestAccSakuraMonitoringSuiteMetricStorageDataSource_basic(t *testing.T) {
 }
 
 var testAccSakuraMonitoringSuiteMetricStorageDataSource_basic = `
-resource "sakura_monitoring_suite_metric_storage" "foobar" {
-  name = "{{ .arg0 }}"
-  description = "description"
-  is_system = false
-}
-
 data "sakura_monitoring_suite_metric_storage" "foobar" {
-  id = sakura_monitoring_suite_metric_storage.foobar.id
+  id = "{{ .arg0 }}"
 }
 `

--- a/internal/service/monitoring_suite/data_source_trace_storage_test.go
+++ b/internal/service/monitoring_suite/data_source_trace_storage_test.go
@@ -4,6 +4,7 @@
 package monitoring_suite_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -11,18 +12,20 @@ import (
 )
 
 func TestAccSakuraMonitoringSuiteTraceStorageDataSource_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_TRACE_STORAGE_ID")
+
 	resourceName := "data.sakura_monitoring_suite_trace_storage.foobar"
-	rand := test.RandomName()
+	id := os.Getenv("SAKURA_MONITORING_SUITE_TRACE_STORAGE_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { test.AccPreCheck(t) },
 		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteTraceStorageDataSource_basic, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteTraceStorageDataSource_basic, id),
 				Check: resource.ComposeTestCheckFunc(
 					test.CheckSakuraDataSourceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf-test"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description"),
 					resource.TestCheckResourceAttr(resourceName, "retention_period_days", "40"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
@@ -36,12 +39,7 @@ func TestAccSakuraMonitoringSuiteTraceStorageDataSource_basic(t *testing.T) {
 }
 
 var testAccSakuraMonitoringSuiteTraceStorageDataSource_basic = `
-resource "sakura_monitoring_suite_trace_storage" "foobar" {
-  name = "{{ .arg0 }}"
-  description = "description"
-}
-
 data "sakura_monitoring_suite_trace_storage" "foobar" {
-  id = sakura_monitoring_suite_trace_storage.foobar.id
+  id = "{{ .arg0 }}"
 }
 `

--- a/internal/service/monitoring_suite/resource_log_storage_access_key_test.go
+++ b/internal/service/monitoring_suite/resource_log_storage_access_key_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -18,8 +19,10 @@ import (
 )
 
 func TestAccSakuraMonitoringSuiteLogStorageAccessKey_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_LOG_STORAGE_ID")
+
 	resourceName := "sakura_monitoring_suite_log_storage_access_key.foobar"
-	rand := test.RandomName()
+	id := os.Getenv("SAKURA_MONITORING_SUITE_LOG_STORAGE_ID")
 
 	var key monitoringsuiteapi.LogStorageAccessKey
 	resource.Test(t, resource.TestCase{
@@ -28,23 +31,23 @@ func TestAccSakuraMonitoringSuiteLogStorageAccessKey_basic(t *testing.T) {
 		CheckDestroy:             testCheckSakuraMonitoringSuiteLogStorageAccessKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteLogStorageAccessKey_basic, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteLogStorageAccessKey_basic, id),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraMonitoringSuiteLogStorageAccessKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "description", "access-key"),
 					resource.TestCheckResourceAttrSet(resourceName, "token"),
 					resource.TestCheckResourceAttrSet(resourceName, "secret"),
-					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "sakura_monitoring_suite_log_storage.foobar", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "data.sakura_monitoring_suite_log_storage.foobar", "id"),
 				),
 			},
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteLogStorageAccessKey_update, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteLogStorageAccessKey_update, id),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraMonitoringSuiteLogStorageAccessKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "description", "access-key-updated"),
 					resource.TestCheckResourceAttrSet(resourceName, "token"),
 					resource.TestCheckResourceAttrSet(resourceName, "secret"),
-					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "sakura_monitoring_suite_log_storage.foobar", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "data.sakura_monitoring_suite_log_storage.foobar", "id"),
 				),
 			},
 		},
@@ -119,29 +122,23 @@ func testCheckSakuraMonitoringSuiteLogStorageAccessKeyExists(n string, key *moni
 }
 
 var testAccSakuraMonitoringSuiteLogStorageAccessKey_basic = `
-resource "sakura_monitoring_suite_log_storage" "foobar" {
-  name = "{{ .arg0 }}"
-  description = "description"
-  classification = "shared"
-  is_system = false
+data "sakura_monitoring_suite_log_storage" "foobar" {
+  id = "{{ .arg0 }}"
 }
 
 resource "sakura_monitoring_suite_log_storage_access_key" "foobar" {
-  storage_id = sakura_monitoring_suite_log_storage.foobar.id
+  storage_id = data.sakura_monitoring_suite_log_storage.foobar.id
   description = "access-key"
 }
 `
 
 var testAccSakuraMonitoringSuiteLogStorageAccessKey_update = `
-resource "sakura_monitoring_suite_log_storage" "foobar" {
-  name = "{{ .arg0 }}"
-  description = "description"
-  classification = "shared"
-  is_system = false
+data "sakura_monitoring_suite_log_storage" "foobar" {
+  id = "{{ .arg0 }}"
 }
 
 resource "sakura_monitoring_suite_log_storage_access_key" "foobar" {
-  storage_id = sakura_monitoring_suite_log_storage.foobar.id
+  storage_id = data.sakura_monitoring_suite_log_storage.foobar.id
   description = "access-key-updated"
 }
 `

--- a/internal/service/monitoring_suite/resource_metric_storage_access_key_test.go
+++ b/internal/service/monitoring_suite/resource_metric_storage_access_key_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -18,8 +19,10 @@ import (
 )
 
 func TestAccSakuraMonitoringSuiteMetricStorageAccessKey_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
+
 	resourceName := "sakura_monitoring_suite_metric_storage_access_key.foobar"
-	rand := test.RandomName()
+	id := os.Getenv("SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
 
 	var key monitoringsuiteapi.MetricsStorageAccessKey
 	resource.Test(t, resource.TestCase{
@@ -28,23 +31,23 @@ func TestAccSakuraMonitoringSuiteMetricStorageAccessKey_basic(t *testing.T) {
 		CheckDestroy:             testCheckSakuraMonitoringSuiteMetricStorageAccessKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteMetricStorageAccessKey_basic, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteMetricStorageAccessKey_basic, id),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraMonitoringSuiteMetricStorageAccessKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "description", "access-key"),
 					resource.TestCheckResourceAttrSet(resourceName, "token"),
 					resource.TestCheckResourceAttrSet(resourceName, "secret"),
-					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "sakura_monitoring_suite_metric_storage.foobar", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "data.sakura_monitoring_suite_metric_storage.foobar", "id"),
 				),
 			},
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteMetricStorageAccessKey_update, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteMetricStorageAccessKey_update, id),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraMonitoringSuiteMetricStorageAccessKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "description", "access-key-updated"),
 					resource.TestCheckResourceAttrSet(resourceName, "token"),
 					resource.TestCheckResourceAttrSet(resourceName, "secret"),
-					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "sakura_monitoring_suite_metric_storage.foobar", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "data.sakura_monitoring_suite_metric_storage.foobar", "id"),
 				),
 			},
 		},
@@ -119,27 +122,23 @@ func testCheckSakuraMonitoringSuiteMetricStorageAccessKeyExists(n string, key *m
 }
 
 var testAccSakuraMonitoringSuiteMetricStorageAccessKey_basic = `
-resource "sakura_monitoring_suite_metric_storage" "foobar" {
-  name = "{{ .arg0 }}"
-  description = "description"
-  is_system = false
+data "sakura_monitoring_suite_metric_storage" "foobar" {
+  id = "{{ .arg0 }}"
 }
 
 resource "sakura_monitoring_suite_metric_storage_access_key" "foobar" {
-  storage_id = sakura_monitoring_suite_metric_storage.foobar.id
+  storage_id = data.sakura_monitoring_suite_metric_storage.foobar.id
   description = "access-key"
 }
 `
 
 var testAccSakuraMonitoringSuiteMetricStorageAccessKey_update = `
-resource "sakura_monitoring_suite_metric_storage" "foobar" {
-  name = "{{ .arg0 }}"
-  description = "description"
-  is_system = false
+data "sakura_monitoring_suite_metric_storage" "foobar" {
+  id = "{{ .arg0 }}"
 }
 
 resource "sakura_monitoring_suite_metric_storage_access_key" "foobar" {
-  storage_id = sakura_monitoring_suite_metric_storage.foobar.id
+  storage_id = data.sakura_monitoring_suite_metric_storage.foobar.id
   description = "access-key-updated"
 }
 `

--- a/internal/service/monitoring_suite/resource_trace_storage_access_key_test.go
+++ b/internal/service/monitoring_suite/resource_trace_storage_access_key_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -18,8 +19,10 @@ import (
 )
 
 func TestAccSakuraMonitoringSuiteTraceStorageAccessKey_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_TRACE_STORAGE_ID")
+
 	resourceName := "sakura_monitoring_suite_trace_storage_access_key.foobar"
-	rand := test.RandomName()
+	id := os.Getenv("SAKURA_MONITORING_SUITE_TRACE_STORAGE_ID")
 
 	var key monitoringsuiteapi.TraceStorageAccessKey
 	resource.Test(t, resource.TestCase{
@@ -28,23 +31,23 @@ func TestAccSakuraMonitoringSuiteTraceStorageAccessKey_basic(t *testing.T) {
 		CheckDestroy:             testCheckSakuraMonitoringSuiteTraceStorageAccessKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteTraceStorageAccessKey_basic, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteTraceStorageAccessKey_basic, id),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraMonitoringSuiteTraceStorageAccessKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "description", "access-key"),
 					resource.TestCheckResourceAttrSet(resourceName, "token"),
 					resource.TestCheckResourceAttrSet(resourceName, "secret"),
-					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "sakura_monitoring_suite_trace_storage.foobar", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "data.sakura_monitoring_suite_trace_storage.foobar", "id"),
 				),
 			},
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteTraceStorageAccessKey_update, rand),
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteTraceStorageAccessKey_update, id),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraMonitoringSuiteTraceStorageAccessKeyExists(resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, "description", "access-key-updated"),
 					resource.TestCheckResourceAttrSet(resourceName, "token"),
 					resource.TestCheckResourceAttrSet(resourceName, "secret"),
-					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "sakura_monitoring_suite_trace_storage.foobar", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "storage_id", "data.sakura_monitoring_suite_trace_storage.foobar", "id"),
 				),
 			},
 		},
@@ -119,25 +122,23 @@ func testCheckSakuraMonitoringSuiteTraceStorageAccessKeyExists(n string, key *mo
 }
 
 var testAccSakuraMonitoringSuiteTraceStorageAccessKey_basic = `
-resource "sakura_monitoring_suite_trace_storage" "foobar" {
-  name = "{{ .arg0 }}"
-  description = "description"
+data "sakura_monitoring_suite_trace_storage" "foobar" {
+  id = "{{ .arg0 }}"
 }
 
 resource "sakura_monitoring_suite_trace_storage_access_key" "foobar" {
-  storage_id = sakura_monitoring_suite_trace_storage.foobar.id
+  storage_id = data.sakura_monitoring_suite_trace_storage.foobar.id
   description = "access-key"
 }
 `
 
 var testAccSakuraMonitoringSuiteTraceStorageAccessKey_update = `
-resource "sakura_monitoring_suite_trace_storage" "foobar" {
-  name = "{{ .arg0 }}"
-  description = "description"
+data "sakura_monitoring_suite_trace_storage" "foobar" {
+  id = "{{ .arg0 }}"
 }
 
 resource "sakura_monitoring_suite_trace_storage_access_key" "foobar" {
-  storage_id = sakura_monitoring_suite_trace_storage.foobar.id
+  storage_id = data.sakura_monitoring_suite_trace_storage.foobar.id
   description = "access-key-updated"
 }
 `


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

モニタリングスイートのストレージは作成負荷が高く、テストで短時間に何十個も連続で作ると不必要な負荷を与えるため、ストレージ生成のテスト以外では作成済みのストレージを参照するようにする。
将来的にはローカルでのテストではsakumockを利用してこれらの制限を回避するようにする。

### ドキュメントの変更は必要ですか？

必要無し