### PR TITLE
monitoring_suite: Fix alert_rule resource and examples

### DIFF
--- a/docs/resources/monitoring_suite_alert_rule.md
+++ b/docs/resources/monitoring_suite_alert_rule.md
@@ -20,8 +20,8 @@ resource "sakura_monitoring_suite_alert_rule" "foobar" {
   query = "count_values"
   enabled_warning = true
   enabled_critical = true
-  threshold_warning = ">=10"
-  threshold_critical = ">=20"
+  threshold_warning = ">= 10"
+  threshold_critical = ">= 20"
   threshold_duration_warning = 600
   threshold_duration_critical = 600
 }

--- a/examples/resources/sakura_monitoring_suite_alert_rule/resource.tf
+++ b/examples/resources/sakura_monitoring_suite_alert_rule/resource.tf
@@ -5,8 +5,8 @@ resource "sakura_monitoring_suite_alert_rule" "foobar" {
   query = "count_values"
   enabled_warning = true
   enabled_critical = true
-  threshold_warning = ">=10"
-  threshold_critical = ">=20"
+  threshold_warning = ">= 10"
+  threshold_critical = ">= 20"
   threshold_duration_warning = 600
   threshold_duration_critical = 600
 }

--- a/internal/service/monitoring_suite/model_alert.go
+++ b/internal/service/monitoring_suite/model_alert.go
@@ -67,8 +67,17 @@ func (model *alertRuleBaseModel) updateState(alertRule *v1.AlertRule) {
 	model.Open = types.BoolValue(alertRule.Open)
 	model.EnabledWarning = types.BoolValue(alertRule.EnabledWarning.Value)
 	model.EnabledCritical = types.BoolValue(alertRule.EnabledCritical.Value)
-	model.ThresholdWarning = types.StringValue(alertRule.ThresholdWarning.Value)
-	model.ThresholdCritical = types.StringValue(alertRule.ThresholdCritical.Value)
+	if alertRule.ThresholdWarning.Value != "" {
+		model.ThresholdWarning = types.StringValue(alertRule.ThresholdWarning.Value)
+	} else {
+		model.ThresholdWarning = types.StringNull()
+	}
+	if alertRule.ThresholdCritical.Value != "" {
+		model.ThresholdCritical = types.StringValue(alertRule.ThresholdCritical.Value)
+	} else {
+		model.ThresholdCritical = types.StringNull()
+	}
+	// 設定されていないDurationはAPIのレスポンスでは120が返ってくるためそのまま値として扱う。
 	model.ThresholdDurationWarning = types.Int64Value(alertRule.ThresholdDurationWarning.Value)
 	model.ThresholdDurationCritical = types.Int64Value(alertRule.ThresholdDurationCritical.Value)
 }

--- a/internal/service/monitoring_suite/resource_alert_rule.go
+++ b/internal/service/monitoring_suite/resource_alert_rule.go
@@ -91,14 +91,17 @@ func (r *alertRuleResource) Schema(ctx context.Context, _ resource.SchemaRequest
 			},
 			"enabled_warning": schema.BoolAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Whether to enable warning level of the Alert Rule.",
 			},
 			"enabled_critical": schema.BoolAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Whether to enable critical level of the Alert Rule.",
 			},
 			"threshold_warning": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "The threshold of warning level of the Alert Rule.",
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(256),
@@ -106,6 +109,7 @@ func (r *alertRuleResource) Schema(ctx context.Context, _ resource.SchemaRequest
 			},
 			"threshold_critical": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "The threshold of critical level of the Alert Rule.",
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(256),
@@ -113,10 +117,12 @@ func (r *alertRuleResource) Schema(ctx context.Context, _ resource.SchemaRequest
 			},
 			"threshold_duration_warning": schema.Int64Attribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "The threshold duration (in seconds) of warning level of the Alert Rule.",
 			},
 			"threshold_duration_critical": schema.Int64Attribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "The threshold duration (in seconds) of critical level of the Alert Rule.",
 			},
 			"open": schema.BoolAttribute{

--- a/internal/service/monitoring_suite/resource_alert_rule.go
+++ b/internal/service/monitoring_suite/resource_alert_rule.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	monitoringsuite "github.com/sacloud/monitoring-suite-api-go"
@@ -92,11 +93,13 @@ func (r *alertRuleResource) Schema(ctx context.Context, _ resource.SchemaRequest
 			"enabled_warning": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 				Description: "Whether to enable warning level of the Alert Rule.",
 			},
 			"enabled_critical": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 				Description: "Whether to enable critical level of the Alert Rule.",
 			},
 			"threshold_warning": schema.StringAttribute{

--- a/internal/service/monitoring_suite/resource_alert_rule.go
+++ b/internal/service/monitoring_suite/resource_alert_rule.go
@@ -104,7 +104,7 @@ func (r *alertRuleResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				Computed:    true,
 				Description: "The threshold of warning level of the Alert Rule.",
 				Validators: []validator.String{
-					stringvalidator.LengthAtMost(256),
+					stringvalidator.LengthBetween(1, 256),
 				},
 			},
 			"threshold_critical": schema.StringAttribute{
@@ -112,7 +112,7 @@ func (r *alertRuleResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				Computed:    true,
 				Description: "The threshold of critical level of the Alert Rule.",
 				Validators: []validator.String{
-					stringvalidator.LengthAtMost(256),
+					stringvalidator.LengthBetween(1, 256),
 				},
 			},
 			"threshold_duration_warning": schema.Int64Attribute{

--- a/internal/service/monitoring_suite/resource_alert_rule_test.go
+++ b/internal/service/monitoring_suite/resource_alert_rule_test.go
@@ -71,6 +71,76 @@ func TestAccSakuraMonitoringSuiteAlertRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccSakuraMonitoringSuiteAlertRule_onlyWarning(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
+
+	resourceName := "sakura_monitoring_suite_alert_rule.foobar"
+	rand := test.RandomName()
+	sId := os.Getenv("SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
+
+	var alertRule monitoringsuiteapi.AlertRule
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraMonitoringSuiteAlertRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteAlertRule_onlyWarning, rand, sId),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraMonitoringSuiteAlertRuleExists(resourceName, &alertRule),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "open"),
+					resource.TestCheckResourceAttrPair(resourceName, "alert_project_id", "sakura_monitoring_suite_alert_project.foobar", "id"),
+					resource.TestCheckResourceAttr(resourceName, "metric_storage_id", sId),
+					resource.TestCheckResourceAttr(resourceName, "query", "count_values"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_warning", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_critical", "false"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_warning", ">=10"),
+					resource.TestCheckNoResourceAttr(resourceName, "threshold_critical"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_duration_warning", "600"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_duration_critical", "120"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSakuraMonitoringSuiteAlertRule_onlyCritical(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
+
+	resourceName := "sakura_monitoring_suite_alert_rule.foobar"
+	rand := test.RandomName()
+	sId := os.Getenv("SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
+
+	var alertRule monitoringsuiteapi.AlertRule
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraMonitoringSuiteAlertRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraMonitoringSuiteAlertRule_onlyCritical, rand, sId),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraMonitoringSuiteAlertRuleExists(resourceName, &alertRule),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "open"),
+					resource.TestCheckResourceAttrPair(resourceName, "alert_project_id", "sakura_monitoring_suite_alert_project.foobar", "id"),
+					resource.TestCheckResourceAttr(resourceName, "metric_storage_id", sId),
+					resource.TestCheckResourceAttr(resourceName, "query", "count_values"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_warning", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_critical", "true"),
+					resource.TestCheckNoResourceAttr(resourceName, "threshold_warning"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_critical", ">=20"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_duration_warning", "120"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_duration_critical", "600"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccImportSakuraMonitoringSuiteAlertRule_basic(t *testing.T) {
 	test.SkipIfEnvIsNotSet(t, "SAKURA_MONITORING_SUITE_METRIC_STORAGE_ID")
 
@@ -212,5 +282,39 @@ resource "sakura_monitoring_suite_alert_rule" "foobar" {
   threshold_critical = ">=40"
   threshold_duration_warning = 600
   threshold_duration_critical = 1200
+}
+`
+
+var testAccSakuraMonitoringSuiteAlertRule_onlyWarning = `
+resource "sakura_monitoring_suite_alert_project" "foobar" {
+  name = "{{ .arg0 }}"
+  description = "description"
+}
+
+resource "sakura_monitoring_suite_alert_rule" "foobar" {
+  alert_project_id = sakura_monitoring_suite_alert_project.foobar.id
+  metric_storage_id = {{ .arg1 }}
+  name = "{{ .arg0 }}"
+  query = "count_values"
+  enabled_warning = true
+  threshold_warning = ">=10"
+  threshold_duration_warning = 600
+}
+`
+
+var testAccSakuraMonitoringSuiteAlertRule_onlyCritical = `
+resource "sakura_monitoring_suite_alert_project" "foobar" {
+  name = "{{ .arg0 }}"
+  description = "description"
+}
+
+resource "sakura_monitoring_suite_alert_rule" "foobar" {
+  alert_project_id = sakura_monitoring_suite_alert_project.foobar.id
+  metric_storage_id = {{ .arg1 }}
+  name = "{{ .arg0 }}"
+  query = "count_values"
+  enabled_critical = true
+  threshold_critical = ">=20"
+  threshold_duration_critical = 600
 }
 `

--- a/internal/service/monitoring_suite/resource_alert_rule_test.go
+++ b/internal/service/monitoring_suite/resource_alert_rule_test.go
@@ -43,8 +43,8 @@ func TestAccSakuraMonitoringSuiteAlertRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "query", "count_values"),
 					resource.TestCheckResourceAttr(resourceName, "enabled_warning", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enabled_critical", "true"),
-					resource.TestCheckResourceAttr(resourceName, "threshold_warning", ">=10"),
-					resource.TestCheckResourceAttr(resourceName, "threshold_critical", ">=20"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_warning", ">= 10"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_critical", ">= 20"),
 					resource.TestCheckResourceAttr(resourceName, "threshold_duration_warning", "600"),
 					resource.TestCheckResourceAttr(resourceName, "threshold_duration_critical", "600"),
 				),
@@ -61,8 +61,8 @@ func TestAccSakuraMonitoringSuiteAlertRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "query", "group"),
 					resource.TestCheckResourceAttr(resourceName, "enabled_warning", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enabled_critical", "false"),
-					resource.TestCheckResourceAttr(resourceName, "threshold_warning", ">=10"),
-					resource.TestCheckResourceAttr(resourceName, "threshold_critical", ">=40"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_warning", ">= 10"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_critical", ">= 40"),
 					resource.TestCheckResourceAttr(resourceName, "threshold_duration_warning", "600"),
 					resource.TestCheckResourceAttr(resourceName, "threshold_duration_critical", "1200"),
 				),
@@ -96,7 +96,7 @@ func TestAccSakuraMonitoringSuiteAlertRule_onlyWarning(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "query", "count_values"),
 					resource.TestCheckResourceAttr(resourceName, "enabled_warning", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enabled_critical", "false"),
-					resource.TestCheckResourceAttr(resourceName, "threshold_warning", ">=10"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_warning", ">= 10"),
 					resource.TestCheckNoResourceAttr(resourceName, "threshold_critical"),
 					resource.TestCheckResourceAttr(resourceName, "threshold_duration_warning", "600"),
 					resource.TestCheckResourceAttr(resourceName, "threshold_duration_critical", "120"),
@@ -132,7 +132,7 @@ func TestAccSakuraMonitoringSuiteAlertRule_onlyCritical(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enabled_warning", "false"),
 					resource.TestCheckResourceAttr(resourceName, "enabled_critical", "true"),
 					resource.TestCheckNoResourceAttr(resourceName, "threshold_warning"),
-					resource.TestCheckResourceAttr(resourceName, "threshold_critical", ">=20"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_critical", ">= 20"),
 					resource.TestCheckResourceAttr(resourceName, "threshold_duration_warning", "120"),
 					resource.TestCheckResourceAttr(resourceName, "threshold_duration_critical", "600"),
 				),
@@ -158,8 +158,8 @@ func TestAccImportSakuraMonitoringSuiteAlertRule_basic(t *testing.T) {
 			"query":                       "count_values",
 			"enabled_warning":             "true",
 			"enabled_critical":            "true",
-			"threshold_warning":           ">=10",
-			"threshold_critical":          ">=20",
+			"threshold_warning":           ">= 10",
+			"threshold_critical":          ">= 20",
 			"threshold_duration_warning":  "600",
 			"threshold_duration_critical": "600",
 		}
@@ -258,8 +258,8 @@ resource "sakura_monitoring_suite_alert_rule" "foobar" {
   query = "count_values"
   enabled_warning = true
   enabled_critical = true
-  threshold_warning = ">=10"
-  threshold_critical = ">=20"
+  threshold_warning = ">= 10"
+  threshold_critical = ">= 20"
   threshold_duration_warning = 600
   threshold_duration_critical = 600
 }
@@ -278,8 +278,8 @@ resource "sakura_monitoring_suite_alert_rule" "foobar" {
   query = "group"
   enabled_warning = true
   enabled_critical = false
-  threshold_warning = ">=10"
-  threshold_critical = ">=40"
+  threshold_warning = ">= 10"
+  threshold_critical = ">= 40"
   threshold_duration_warning = 600
   threshold_duration_critical = 1200
 }
@@ -297,7 +297,7 @@ resource "sakura_monitoring_suite_alert_rule" "foobar" {
   name = "{{ .arg0 }}"
   query = "count_values"
   enabled_warning = true
-  threshold_warning = ">=10"
+  threshold_warning = ">= 10"
   threshold_duration_warning = 600
 }
 `
@@ -314,7 +314,7 @@ resource "sakura_monitoring_suite_alert_rule" "foobar" {
   name = "{{ .arg0 }}"
   query = "count_values"
   enabled_critical = true
-  threshold_critical = ">=20"
+  threshold_critical = ">= 20"
   threshold_duration_critical = 600
 }
 `


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

alert ruleのAPIレスポンスには設定してないものでも値が返ってくるものがあり、それらによって設定と状態でミスマッチが起きていたのでcomputedをつけることで解決する。

### ドキュメントの変更は必要ですか？

`threshold_xxx` のサンプルが間違っているのでそれも一緒に修正する。 `>=10` to `>= 10`
