### PR TITLE
SEG: zone needed for import

### DIFF
--- a/docs/resources/seg.md
+++ b/docs/resources/seg.md
@@ -90,3 +90,14 @@ Optional:
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+# Specify the ID in the format of {zone}/{id}: e.g. "tk1b/113801540562"
+terraform import sakura_seg.foo '{zone}/{id}'
+```

--- a/docs/resources/seg.md
+++ b/docs/resources/seg.md
@@ -100,4 +100,8 @@ The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/c
 ```shell
 # Specify the ID in the format of {zone}/{id}: e.g. "tk1b/113801540562"
 terraform import sakura_seg.foo '{zone}/{id}'
+
+# You can also omit the zone
+# Doing so implies the default zone specified in the provider configuration.
+terraform import sakura_seg.foo '{id}'
 ```

--- a/examples/resources/sakura_seg/import.sh
+++ b/examples/resources/sakura_seg/import.sh
@@ -1,0 +1,2 @@
+# Specify the ID in the format of {zone}/{id}: e.g. "tk1b/113801540562"
+terraform import sakura_seg.foo '{zone}/{id}'

--- a/examples/resources/sakura_seg/import.sh
+++ b/examples/resources/sakura_seg/import.sh
@@ -1,2 +1,6 @@
 # Specify the ID in the format of {zone}/{id}: e.g. "tk1b/113801540562"
 terraform import sakura_seg.foo '{zone}/{id}'
+
+# You can also omit the zone
+# Doing so implies the default zone specified in the provider configuration.
+terraform import sakura_seg.foo '{id}'

--- a/internal/service/seg/resource.go
+++ b/internal/service/seg/resource.go
@@ -166,6 +166,11 @@ func (r *segResource) ImportState(ctx context.Context, req resource.ImportStateR
 	// Import format: zone/resource_id
 	parts := strings.Split(req.ID, "/")
 
+	if len(parts) == 1 {
+		zone := common.GetZone(types.StringUnknown(), r.client, &resp.Diagnostics)
+		parts = []string{zone, parts[0]}
+	}
+
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		resp.Diagnostics.AddError(
 			"Import: Invalid ID",

--- a/internal/service/seg/resource.go
+++ b/internal/service/seg/resource.go
@@ -6,6 +6,7 @@ package seg
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
@@ -162,7 +163,19 @@ func (r *segResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 }
 
 func (r *segResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	// Import format: zone/resource_id
+	parts := strings.Split(req.ID, "/")
+
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Import: Invalid ID",
+			fmt.Sprintf("Expected format: zone/resource_id, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("zone"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
 }
 
 func (r *segResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/service/seg/resource.go
+++ b/internal/service/seg/resource.go
@@ -166,10 +166,10 @@ func (r *segResource) ImportState(ctx context.Context, req resource.ImportStateR
 	// Import format: zone/resource_id
 	parts := strings.Split(req.ID, "/")
 
-	if len(parts) != 2 {
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		resp.Diagnostics.AddError(
 			"Import: Invalid ID",
-			fmt.Sprintf("Expected format: zone/resource_id, got: %s", req.ID),
+			fmt.Sprintf("Expected format: zone/resource_id, got: %q", req.ID),
 		)
 		return
 	}

--- a/internal/service/seg/resource.go
+++ b/internal/service/seg/resource.go
@@ -174,7 +174,7 @@ func (r *segResource) ImportState(ctx context.Context, req resource.ImportStateR
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		resp.Diagnostics.AddError(
 			"Import: Invalid ID",
-			fmt.Sprintf("Expected format: zone/resource_id, got: %q", req.ID),
+			fmt.Sprintf("Expected format: zone/id, got: %q", req.ID),
 		)
 		return
 	}

--- a/internal/service/seg/resource_test.go
+++ b/internal/service/seg/resource_test.go
@@ -75,6 +75,20 @@ func TestAccSakuraSEG_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("not found: %s", resourceName)
+					}
+					zone := rs.Primary.Attributes["zone"]
+					id := rs.Primary.Attributes["id"]
+					return fmt.Sprintf("%s/%s", zone, id), nil
+				},
+			},
+			{
 				Config: test.BuildConfigWithArgs(testAccSakuraSEGUpdate, rand, objectStorageEndpoint1),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraSEGExists(resourceName),


### PR DESCRIPTION
- SEGをimportする際に別のゾーンから読むことは仕組み上できません。こちらのスレッド参照 https://github.com/sacloud/terraform-provider-sakura/pull/186#pullrequestreview-4086181591
- というわけなのでzoneを指定してもらうことにします