### PR TITLE
object_storage: fix permission's import

### DIFF
--- a/docs/resources/object_storage_permission.md
+++ b/docs/resources/object_storage_permission.md
@@ -64,3 +64,14 @@ Optional:
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
 - `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+# Specify the ID in the format of {site_id}/{id}: e.g. "tky01/12345"
+terraform import sakura_object_storage_permission.foo '{site_id}/{id}'
+```

--- a/examples/resources/sakura_object_storage_permission/import.sh
+++ b/examples/resources/sakura_object_storage_permission/import.sh
@@ -1,0 +1,2 @@
+# Specify the ID in the format of {site_id}/{id}: e.g. "tky01/12345"
+terraform import sakura_object_storage_permission.foo '{site_id}/{id}'

--- a/internal/service/object_storage/resource_permission.go
+++ b/internal/service/object_storage/resource_permission.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -119,7 +120,17 @@ func (r *objectStoragePermissionResource) Schema(ctx context.Context, _ resource
 }
 
 func (r *objectStoragePermissionResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	parts := strings.SplitN(req.ID, "/", 2)
+
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError("Import Error",
+			fmt.Sprintf("invalid import ID format. Please specify the import ID in the format of {site_id}/{id}: %s", req.ID))
+		return
+	}
+
+	resp.Diagnostics.AddWarning("Import Warning", "the access_key and secret_key for object storage permission will not be imported. You will need to create a new access_key and secret_key or use the existing ones from the state.")
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("site_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
 }
 
 func (r *objectStoragePermissionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/service/object_storage/resource_permission_test.go
+++ b/internal/service/object_storage/resource_permission_test.go
@@ -62,6 +62,55 @@ func TestAccSakuraObjectStoragePermission_basic(t *testing.T) {
 	})
 }
 
+func TestAccImportSakuraObjectStoragePermission_basic(t *testing.T) {
+	rand := test.RandomName()
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+		expects := map[string]string{
+			"name":                        "tf-permission-test-" + rand,
+			"site_id":                     "tky01",
+			"bucket_controls.#":           "1",
+			"bucket_controls.0.bucket":    "tf-permission-test-tky1-" + rand,
+			"bucket_controls.0.can_read":  "true",
+			"bucket_controls.0.can_write": "true",
+		}
+
+		if err := test.CompareStateMulti(s[0], expects); err != nil {
+			return err
+		}
+		return test.StateNotEmptyMulti(s[0])
+	}
+
+	resourceName := "sakura_object_storage_permission.foobar"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraObjectStoragePermissionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraObjectStoragePermission_import, rand),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateCheck:        checkFn,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"access_key", "secret_key"},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("resource not found: %s", resourceName)
+					}
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["site_id"], rs.Primary.Attributes["id"]), nil
+				},
+			},
+		},
+	})
+}
+
 func testCheckSakuraObjectStoragePermissionExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -171,5 +220,25 @@ resource "sakura_object_storage_permission" "foobar" {
     bucket = sakura_object_storage_bucket.foobar2.name
     can_read = true
     can_write = false
+  }]
+}`
+
+const testAccSakuraObjectStoragePermission_import = `
+data "sakura_object_storage_site" "foobar" {
+  id = "tky01"
+}
+
+resource "sakura_object_storage_bucket" "foobar1" {
+  name    = "tf-permission-test-tky1-{{ .arg0 }}"
+  site_id = data.sakura_object_storage_site.foobar.id
+}
+
+resource "sakura_object_storage_permission" "foobar" {
+  name = "tf-permission-test-{{ .arg0 }}"
+  site_id = data.sakura_object_storage_site.foobar.id
+  bucket_controls = [{
+    bucket = sakura_object_storage_bucket.foobar1.name
+    can_read = true
+    can_write = true
   }]
 }`


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes https://github.com/sacloud/terraform-provider-sakura/issues/287

### このPRはどういう変更を行いますか？

オブジェクトストレージのPermissionのimportが動かない問題の修正。
importでは重要なaccess_key/secret_keyが取得できないので、その旨をWarningで表示

### ドキュメントの変更は必要ですか？

importの例を追加。