### PR TITLE
vpn_router: Use Set for firewall to fix unordered problem

### DIFF
--- a/docs/data-sources/vpn_router.md
+++ b/docs/data-sources/vpn_router.md
@@ -34,7 +34,7 @@ data "sakura_vpn_router" "foobar" {
 - `dhcp_server` (Attributes List) (see [below for nested schema](#nestedatt--dhcp_server))
 - `dhcp_static_mapping` (Attributes List) (see [below for nested schema](#nestedatt--dhcp_static_mapping))
 - `dns_forwarding` (Attributes) (see [below for nested schema](#nestedatt--dns_forwarding))
-- `firewall` (Attributes List) (see [below for nested schema](#nestedatt--firewall))
+- `firewall` (Attributes Set) (see [below for nested schema](#nestedatt--firewall))
 - `icon_id` (String) The icon id attached to the VPN Router
 - `internet_connection` (Boolean) The flag to enable connecting to the Internet from the VPN Router
 - `l2tp` (Attributes) (see [below for nested schema](#nestedatt--l2tp))

--- a/docs/resources/vpn_router.md
+++ b/docs/resources/vpn_router.md
@@ -189,7 +189,7 @@ resource "sakura_vswitch" "foobar" {
 - `dhcp_server` (Attributes List) (see [below for nested schema](#nestedatt--dhcp_server))
 - `dhcp_static_mapping` (Attributes List) (see [below for nested schema](#nestedatt--dhcp_static_mapping))
 - `dns_forwarding` (Attributes) (see [below for nested schema](#nestedatt--dns_forwarding))
-- `firewall` (Attributes List) (see [below for nested schema](#nestedatt--firewall))
+- `firewall` (Attributes Set) (see [below for nested schema](#nestedatt--firewall))
 - `icon_id` (String) The icon id to attach to the VPN Router
 - `internet_connection` (Boolean) The flag to enable connecting to the Internet from the VPN Router
 - `l2tp` (Attributes) (see [below for nested schema](#nestedatt--l2tp))

--- a/internal/service/vpn_router/data_source.go
+++ b/internal/service/vpn_router/data_source.go
@@ -200,7 +200,7 @@ func (d *vpnRouterDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 					},
 				},
 			},
-			"firewall": schema.ListNestedAttribute{
+			"firewall": schema.SetNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/service/vpn_router/resource.go
+++ b/internal/service/vpn_router/resource.go
@@ -296,7 +296,7 @@ func (d *vpnRouterResource) Schema(ctx context.Context, _ resource.SchemaRequest
 					},
 				},
 			},
-			"firewall": schema.ListNestedAttribute{
+			"firewall": schema.SetNestedAttribute{
 				Optional: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/service/vpn_router/resource_test.go
+++ b/internal/service/vpn_router/resource_test.go
@@ -44,11 +44,50 @@ func TestAccSakuraVPNRouter_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "public_network_interface.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_netmask"),
-					resource.TestCheckResourceAttrPair(
-						resourceName, "icon_id",
-						"sakura_icon.foobar", "id",
-					),
+					resource.TestCheckResourceAttrPair(resourceName, "icon_id", "sakura_icon.foobar", "id"),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_suite.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "firewall.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "firewall.*", map[string]string{
+						"interface_index":               "0",
+						"direction":                     "send",
+						"expression.#":                  "3",
+						"expression.0.protocol":         "tcp",
+						"expression.0.destination_port": "30000-40000",
+						"expression.0.allow":            "true",
+						"expression.0.logging":          "false",
+						"expression.1.protocol":         "udp",
+						"expression.1.destination_port": "30000-40000",
+						"expression.1.allow":            "true",
+						"expression.1.logging":          "false",
+						"expression.2.protocol":         "tcp",
+						"expression.2.destination_port": "80,443,4317",
+						"expression.2.description":      "HTTP,HTTPS",
+						"expression.2.allow":            "true",
+						"expression.2.logging":          "false",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "firewall.*", map[string]string{
+						"interface_index":               "0",
+						"direction":                     "receive",
+						"expression.#":                  "2",
+						"expression.0.protocol":         "tcp",
+						"expression.0.destination_port": "30000-40000",
+						"expression.0.allow":            "true",
+						"expression.0.logging":          "false",
+						"expression.1.protocol":         "udp",
+						"expression.1.destination_port": "30000-40000",
+						"expression.1.allow":            "true",
+						"expression.1.logging":          "false",
+					}),
+
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "firewall.*", map[string]string{
+						"interface_index":               "1",
+						"direction":                     "receive",
+						"expression.#":                  "1",
+						"expression.0.protocol":         "tcp",
+						"expression.0.destination_port": "30000-40000",
+						"expression.0.allow":            "true",
+						"expression.0.logging":          "false",
+					}),
 				),
 			},
 			{
@@ -68,6 +107,33 @@ func TestAccSakuraVPNRouter_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_netmask"),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_suite.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "firewall.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "firewall.*", map[string]string{
+						"interface_index":               "0",
+						"direction":                     "send",
+						"expression.#":                  "2",
+						"expression.0.protocol":         "tcp",
+						"expression.0.destination_port": "30000-40000",
+						"expression.0.allow":            "true",
+						"expression.0.logging":          "false",
+						"expression.1.protocol":         "udp",
+						"expression.1.destination_port": "30000-40000",
+						"expression.1.allow":            "true",
+						"expression.1.logging":          "false",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "firewall.*", map[string]string{
+						"interface_index":               "0",
+						"direction":                     "receive",
+						"expression.#":                  "2",
+						"expression.0.protocol":         "tcp",
+						"expression.0.destination_port": "30000-40000",
+						"expression.0.allow":            "true",
+						"expression.0.logging":          "false",
+						"expression.1.protocol":         "udp",
+						"expression.1.destination_port": "30000-40000",
+						"expression.1.allow":            "true",
+						"expression.1.logging":          "false",
+					}),
 				),
 			},
 		},
@@ -146,21 +212,23 @@ func TestAccSakuraVPNRouter_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "dns_forwarding.dns_servers.0", "133.242.0.3"),
 					resource.TestCheckResourceAttr(resourceName, "dns_forwarding.dns_servers.1", "133.242.0.4"),
 					resource.TestCheckResourceAttr(resourceName, "firewall.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.interface_index", "1"),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.direction", "send"),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.0.protocol", "tcp"),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.0.allow", "true"),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.0.source_network", ""),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.0.source_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.0.destination_network", ""),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.0.destination_port", ""),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.1.protocol", "ip"),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.1.allow", "false"),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.1.source_network", ""),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.1.source_port", ""),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.1.destination_network", ""),
-					resource.TestCheckResourceAttr(resourceName, "firewall.0.expression.1.destination_port", ""),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "firewall.*", map[string]string{
+						"interface_index":                  "1",
+						"direction":                        "send",
+						"expression.#":                     "2",
+						"expression.0.protocol":            "tcp",
+						"expression.0.allow":               "true",
+						"expression.0.source_network":      "",
+						"expression.0.source_port":         "80",
+						"expression.0.destination_network": "",
+						"expression.0.destination_port":    "",
+						"expression.1.protocol":            "ip",
+						"expression.1.allow":               "false",
+						"expression.1.source_network":      "",
+						"expression.1.source_port":         "",
+						"expression.1.destination_network": "",
+						"expression.1.destination_port":    "",
+					}),
 					resource.TestCheckResourceAttr(resourceName, "l2tp.pre_shared_secret", "example"),
 					resource.TestCheckResourceAttr(resourceName, "l2tp.range_start", "192.168.11.21"),
 					resource.TestCheckResourceAttr(resourceName, "l2tp.range_stop", "192.168.11.30"),
@@ -358,6 +426,80 @@ resource "sakura_vpn_router" "foobar" {
   icon_id             = sakura_icon.foobar.id
   internet_connection = true
 
+  firewall = [{
+    interface_index = 1
+    direction       = "receive"
+    expression = [
+      {
+        protocol            = "tcp"
+        destination_port    = "30000-40000"
+        allow               = true
+        logging             = false
+        destination_network = ""
+        source_network      = ""
+        source_port         = ""
+      }
+    ]
+  },
+  {
+    interface_index = 0
+    direction       = "receive"
+    expression = [
+      {
+        protocol            = "tcp"
+        destination_port    = "30000-40000"
+        allow               = true
+        logging             = false
+        destination_network = ""
+        source_network      = ""
+        source_port         = ""
+      },
+      {
+        protocol            = "udp"
+        destination_port    = "30000-40000"
+        allow               = true
+        logging             = false
+        destination_network = ""
+        source_network      = ""
+        source_port         = ""
+      }
+    ]
+  },
+  {
+    interface_index = 0
+    direction = "send"
+    expression = [
+      {
+        protocol            = "tcp"
+        destination_port    = "30000-40000"
+        allow               = true
+        logging             = false
+        destination_network = ""
+        source_network      = ""
+        source_port         = ""
+      },
+      {
+        protocol            = "udp"
+        destination_port    = "30000-40000"
+        allow               = true
+        logging             = false
+        destination_network = ""
+        source_network      = ""
+        source_port         = ""
+      },
+      {
+        protocol            = "tcp"
+        destination_port    = "80,443,4317"
+        allow               = true
+        logging             = false
+        description         = "HTTP,HTTPS"
+        destination_network = ""
+        source_network      = ""
+        source_port         = ""
+      },
+    ]
+  }]
+
   monitoring_suite = {
     enabled = true
   }
@@ -376,6 +518,55 @@ resource "sakura_vpn_router" "foobar" {
   tags                = ["tag1-upd", "tag2-upd"]
   syslog_host         = "192.168.0.2"
   internet_connection = false
+
+  firewall = [{
+    interface_index = 0
+    direction = "send"
+    expression = [
+      {
+        protocol            = "tcp"
+        destination_port    = "30000-40000"
+        allow               = true
+        logging             = false
+        destination_network = ""
+        source_network      = ""
+        source_port         = ""
+      },
+      {
+        protocol            = "udp"
+        destination_port    = "30000-40000"
+        allow               = true
+        logging             = false
+        destination_network = ""
+        source_network      = ""
+        source_port         = ""
+      },
+    ]
+  },
+  {
+    interface_index = 0
+    direction       = "receive"
+    expression = [
+      {
+        protocol            = "tcp"
+        destination_port    = "30000-40000"
+        allow               = true
+        logging             = false
+        destination_network = ""
+        source_network      = ""
+        source_port         = ""
+      },
+      {
+        protocol            = "udp"
+        destination_port    = "30000-40000"
+        allow               = true
+        logging             = false
+        destination_network = ""
+        source_network      = ""
+        source_port         = ""
+      }
+    ]
+  }]
 
   monitoring_suite = {
     enabled = false


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

vpn_routerのfirewallはList型だが内部の実装の一部でmapを使っており、実はsend/receiveの順序が不定になっていて、その結果terraform applyでconfig/stateのinconsistency errorが起きることがあった。この挙動に関してはv2でも起きていたが、v2では厳密なチェックがされていなかったため顕在化せず見逃されていた。

修正案として、Setを使う、send/receive/indexの順序をドキュメント化してvalidateをする、の2つが考えられたが後者は設定の書き方に制限ができるのに加えて実装難易度もあがるので、今回は前者を採用する。SetはListと書き方が同じで互換性があるため、ユーザに追加作業は発生しない。
通常のテストの設定にfirewallを追加。

```
=== RUN   TestAccSakuraVPNRouterDataSource_Basic
--- PASS: TestAccSakuraVPNRouterDataSource_Basic (488.19s)
=== RUN   TestAccSakuraVPNRouter_basic
--- PASS: TestAccSakuraVPNRouter_basic (670.16s)
=== RUN   TestAccImportSakuraVPNRouter_basic
--- PASS: TestAccImportSakuraVPNRouter_basic (429.50s)
=== RUN   TestAccSakuraVPNRouter_Full
--- PASS: TestAccSakuraVPNRouter_Full (976.68s)
=== RUN   TestAccSakuraVPNRouter_WOFull
--- PASS: TestAccSakuraVPNRouter_WOFull (716.83s)
PASS
ok  	github.com/sacloud/terraform-provider-sakura/internal/service/vpn_router	3282.174s
```

### ドキュメントの変更は必要ですか？

型が変わったので再生成。