### PR TITLE
workflows: fix workflows's update action. fix #291

### DIFF
--- a/docs/resources/seg.md
+++ b/docs/resources/seg.md
@@ -69,7 +69,7 @@ Required:
 
 Optional:
 
-- `dns_servers` (List of String) The name of upstream DNS servers for DNS forwarding
+- `dns_servers` (List of String) The name of upstream DNS servers for DNS forwarding (must contain exactly 2 servers)
 - `private_hosted_zone` (String) The private hosted zone name for DNS forwarding
 
 

--- a/internal/service/workflows/resource.go
+++ b/internal/service/workflows/resource.go
@@ -161,19 +161,14 @@ func (r *workflowResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	// NOTE: createWorkflowで作ったrevisionのIDはレスポンスに無いため、リビジョンの一覧取得にて確認しステートに保存
-	revisionOp := workflows.NewRevisionOp(r.client)
-	revisions, err := revisionOp.List(ctx, v1.ListWorkflowRevisionsParams{ID: workflow.ID})
+	revisions, err := getWorkflowRevisions(ctx, r.client, workflow.ID)
 	if err != nil {
-		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to list created Workflow[%s] revisions: %s", workflow.ID, err))
-		return
-	}
-	if len(revisions.Revisions) == 0 {
-		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to list created Workflow[%s] revisions: no error but revisions are empty. Workflows API something went wrong", workflow.ID))
+		resp.Diagnostics.AddError("Create: API Error", err.Error())
 		return
 	}
 
 	plan.updateStateFromCreated(workflow)
-	plan.updateRevisionsState(revisions.Revisions)
+	plan.updateRevisionsState(revisions)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -193,19 +188,14 @@ func (r *workflowResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 
 	// NOTE: revisionのIDはRead workflowのレスポンスに無いため、まとめて一覧取得しステートに保存
-	revisionOp := workflows.NewRevisionOp(r.client)
-	revisions, err := revisionOp.List(ctx, v1.ListWorkflowRevisionsParams{ID: workflow.ID})
+	revisions, err := getWorkflowRevisions(ctx, r.client, workflow.ID)
 	if err != nil {
-		resp.Diagnostics.AddError("Read: API Error", fmt.Sprintf("failed to list Workflow[%s] revisions: %s", workflow.ID, err))
-		return
-	}
-	if len(revisions.Revisions) == 0 {
-		resp.Diagnostics.AddError("Read: API Error", fmt.Sprintf("failed to list Workflow[%s] revisions: no error but revisions are empty. Workflows API something went wrong", workflow.ID))
+		resp.Diagnostics.AddError("Read: API Error", err.Error())
 		return
 	}
 
 	state.updateState(workflow)
-	state.updateRevisionsState(revisions.Revisions)
+	state.updateRevisionsState(revisions)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -248,6 +238,13 @@ func (r *workflowResource) Update(ctx context.Context, req resource.UpdateReques
 		plan.LatestRevision.Runbook = types.StringValue(latestRevision.Runbook)
 		plan.LatestRevision.CreatedAt = types.StringValue(latestRevision.CreatedAt.String())
 		plan.LatestRevision.UpdatedAt = types.StringValue(latestRevision.UpdatedAt.String())
+	} else {
+		revisions, err := getWorkflowRevisions(ctx, r.client, workflow.ID)
+		if err != nil {
+			resp.Diagnostics.AddError("Update: API Error", err.Error())
+			return
+		}
+		plan.updateRevisionsState(revisions)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -268,4 +265,16 @@ func (r *workflowResource) Delete(ctx context.Context, req resource.DeleteReques
 		resp.Diagnostics.AddError("Delete: API Error", fmt.Sprintf("failed to delete Workflow: %s", err))
 		return
 	}
+}
+
+func getWorkflowRevisions(ctx context.Context, client *v1.Client, workflowID string) ([]v1.ListWorkflowRevisionsOKRevisionsItem, error) {
+	revisionOp := workflows.NewRevisionOp(client)
+	revisions, err := revisionOp.List(ctx, v1.ListWorkflowRevisionsParams{ID: workflowID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list created Workflow[%s] revisions: %w", workflowID, err)
+	}
+	if len(revisions.Revisions) == 0 {
+		return nil, fmt.Errorf("failed to list created Workflow[%s] revisions: no error but revisions are empty. Workflows API something went wrong", workflowID)
+	}
+	return revisions.Revisions, nil
 }

--- a/internal/service/workflows/resource.go
+++ b/internal/service/workflows/resource.go
@@ -271,10 +271,10 @@ func getWorkflowRevisions(ctx context.Context, client *v1.Client, workflowID str
 	revisionOp := workflows.NewRevisionOp(client)
 	revisions, err := revisionOp.List(ctx, v1.ListWorkflowRevisionsParams{ID: workflowID})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list created Workflow[%s] revisions: %w", workflowID, err)
+		return nil, fmt.Errorf("failed to list Workflow[%s] revisions: %w", workflowID, err)
 	}
 	if len(revisions.Revisions) == 0 {
-		return nil, fmt.Errorf("failed to list created Workflow[%s] revisions: no error but revisions are empty. Workflows API something went wrong", workflowID)
+		return nil, fmt.Errorf("failed to list Workflow[%s] revisions: no error but revisions are empty. Workflows API something went wrong", workflowID)
 	}
 	return revisions.Revisions, nil
 }

--- a/internal/service/workflows/resource_test.go
+++ b/internal/service/workflows/resource_test.go
@@ -67,6 +67,49 @@ func TestAccSakuraResourceWorkflows_basic(t *testing.T) {
 	})
 }
 
+// Test for https://github.com/sacloud/terraform-provider-sakura/issues/291
+func TestAccSakuraResourceWorkflows_sameLatestRevision(t *testing.T) {
+	resourceName := "sakura_workflows.foobar"
+	rand := test.RandomName()
+
+	var workflow v1.GetWorkflowOKWorkflow
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy:             testCheckSakuraWorkflowsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraWorkflows_sameLatestRevision, rand, sampleRunbookV1Escaped),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraWorkflowsExists(resourceName, &workflow),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "publish", "false"),
+					resource.TestCheckResourceAttr(resourceName, "logging", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "subscription_id", "sakura_workflows_subscription.foobar", "id"),
+					resource.TestCheckResourceAttr(resourceName, "latest_revision.runbook", sampleRunbookV1),
+					resource.TestCheckResourceAttrSet(resourceName, "latest_revision.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "latest_revision.created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "latest_revision.updated_at"),
+				),
+			},
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraWorkflows_updateSameLatestRevision, rand, sampleRunbookV1Escaped),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraWorkflowsExists(resourceName, &workflow),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "publish", "true"),
+					resource.TestCheckResourceAttr(resourceName, "logging", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "subscription_id", "sakura_workflows_subscription.foobar", "id"),
+					resource.TestCheckResourceAttr(resourceName, "latest_revision.runbook", sampleRunbookV1),
+					resource.TestCheckResourceAttrSet(resourceName, "latest_revision.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "latest_revision.created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "latest_revision.updated_at"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccSakuraResourceWorkflows_invalidName(t *testing.T) {
 	randInvalid := test.RandomName() + "./+invalid"
 
@@ -214,5 +257,45 @@ resource "sakura_workflows" "foobar" {
 
   latest_revision = {
     runbook = yamlencode({{ .arg1 }})
+  }
+}`
+
+var testAccSakuraWorkflows_sameLatestRevision = `
+data "sakura_workflows_plan" "foobar" {
+  name = "200K"
+}
+
+resource "sakura_workflows_subscription" "foobar" {
+  plan_id = data.sakura_workflows_plan.foobar.id
+}
+
+resource "sakura_workflows" "foobar" {
+  subscription_id = sakura_workflows_subscription.foobar.id
+  name            = "{{ .arg0 }}"
+  publish         = false
+  logging         = false
+  latest_revision = {
+    runbook = <<-EOF
+{{ .arg1 }}EOF
+  }
+}`
+
+var testAccSakuraWorkflows_updateSameLatestRevision = `
+data "sakura_workflows_plan" "foobar" {
+  name = "200K"
+}
+
+resource "sakura_workflows_subscription" "foobar" {
+  plan_id = data.sakura_workflows_plan.foobar.id
+}
+
+resource "sakura_workflows" "foobar" {
+  subscription_id = sakura_workflows_subscription.foobar.id
+  name            = "{{ .arg0 }}"
+  publish         = true
+  logging         = false
+  latest_revision = {
+    runbook = <<-EOF
+{{ .arg1 }}EOF
   }
 }`


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #291 

### このPRはどういう変更を行いますか？

workflowsリソースのupdateにおいて、latest_revisionのrunbookが更新されていない時に状態が壊れる問題を修正。terraform外でrunbookが修正されていた場合update前のread呼び出してドリフト検出されてrunbookの更新が走るので、runbook未更新の場合にはstateの状態をコピーするだけでも十分だが、とりあえず他のアクションと処理をあわせるため最新リビジョンを取得して設定するようにしている。

テストは手元では全てパス。

```
=== RUN   TestAccSakuraDataSourceWorkflowPlan_basic
--- PASS: TestAccSakuraDataSourceWorkflowPlan_basic (1.01s)
=== RUN   TestAccSakuraDataSourceWorkflowPlan_multipleMatches
--- PASS: TestAccSakuraDataSourceWorkflowPlan_multipleMatches (0.32s)
=== RUN   TestAccSakuraDataSourceWorkflowsRevisionAlias_basic
--- PASS: TestAccSakuraDataSourceWorkflowsRevisionAlias_basic (9.17s)
=== RUN   TestAccSakuraDataSourceWorkflowsSubscription_basic
--- PASS: TestAccSakuraDataSourceWorkflowsSubscription_basic (3.91s)
=== RUN   TestAccSakuraDataSourceWorkflows_basic
--- PASS: TestAccSakuraDataSourceWorkflows_basic (5.57s)
=== RUN   TestAccSakuraResourceWorkflowsRevisionAlias_basic
--- PASS: TestAccSakuraResourceWorkflowsRevisionAlias_basic (9.71s)
=== RUN   TestAccSakuraResourceWorkflowsRevisionAlias_validation
=== PAUSE TestAccSakuraResourceWorkflowsRevisionAlias_validation
=== RUN   TestAccSakuraResourceWorkflowsRevisionAlias_workflowUpdate
--- PASS: TestAccSakuraResourceWorkflowsRevisionAlias_workflowUpdate (8.56s)
=== RUN   TestAccSakuraResourceWorkflowsSubscription_basic
--- PASS: TestAccSakuraResourceWorkflowsSubscription_basic (6.19s)
=== RUN   TestAccSakuraResourceWorkflows_basic
--- PASS: TestAccSakuraResourceWorkflows_basic (6.92s)
=== RUN   TestAccSakuraResourceWorkflows_sameLatestRevision
--- PASS: TestAccSakuraResourceWorkflows_sameLatestRevision (8.23s)
=== RUN   TestAccSakuraResourceWorkflows_invalidName
--- PASS: TestAccSakuraResourceWorkflows_invalidName (0.15s)
=== CONT  TestAccSakuraResourceWorkflowsRevisionAlias_validation
--- PASS: TestAccSakuraResourceWorkflowsRevisionAlias_validation (0.24s)
PASS
ok  	github.com/sacloud/terraform-provider-sakura/internal/service/workflows	60.599s
```

### ドキュメントの変更は必要ですか？

本来は必要ないが、 https://github.com/sacloud/terraform-provider-sakura/pull/285 のドキュメントの更新がされてなかったようなので、それを含んでいる。