### PR TITLE
vpn_router: Remove default from firewall.logging attribute to avoid unexpected plan change

### DIFF
--- a/internal/service/vpn_router/resource.go
+++ b/internal/service/vpn_router/resource.go
@@ -353,7 +353,6 @@ func (d *vpnRouterResource) Schema(ctx context.Context, _ resource.SchemaRequest
 									"logging": schema.BoolAttribute{
 										Optional:    true,
 										Computed:    true,
-										Default:     booldefault.StaticBool(false),
 										Description: "The flag to enable packet logging when matching the expression",
 									},
 									"description": common.SchemaResourceDescription("firewall expression"),


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

https://github.com/sacloud/terraform-provider-sakura/pull/286 で意図しない挙動をさせないためにboolにdefaultをつけたが、これによって意図しないplanが発生するようになったので変更を戻す。今回の問題に関してはSetNestedAttributeでのみ起きているのでvpn_routerの変更だけ対象とする。
framework側にほぼ同じ問題が起きている人のissueが建てられているが修正はされてない: https://github.com/hashicorp/terraform-plugin-framework/issues/867

### ドキュメントの変更は必要ですか？

必要無し。