### PR TITLE
Use router+switch instead of switch+router

### DIFF
--- a/docs/data-sources/internet.md
+++ b/docs/data-sources/internet.md
@@ -3,12 +3,12 @@
 page_title: "sakura_internet Data Source - sakura"
 subcategory: "Networking"
 description: |-
-  Get information about an existing Internet(Switch + Router).
+  Get information about an existing Internet(router+switch).
 ---
 
 # sakura_internet (Data Source)
 
-Get information about an existing Internet(Switch + Router).
+Get information about an existing Internet(router+switch).
 
 ## Example Usage
 

--- a/docs/data-sources/internet.md
+++ b/docs/data-sources/internet.md
@@ -23,25 +23,25 @@ data "sakura_internet" "foobar" {
 
 ### Optional
 
-- `id` (String) The ID of the Internet(switch+router).
-- `name` (String) The name of the Internet(switch+router).
-- `tags` (Set of String) The tags of the Internet(switch+router).
-- `zone` (String) The name of zone that the Internet(switch+router) is in (e.g. `is1a`, `tk1a`)
+- `id` (String) The ID of the Internet(router+switch).
+- `name` (String) The name of the Internet(router+switch).
+- `tags` (Set of String) The tags of the Internet(router+switch).
+- `zone` (String) The name of zone that the Internet(router+switch) is in (e.g. `is1a`, `tk1a`)
 
 ### Read-Only
 
 - `band_width` (Number) The bandwidth of the network connected to the Internet in Mbps
-- `description` (String) The description of the Internet(switch+router).
+- `description` (String) The description of the Internet(router+switch).
 - `enable_ipv6` (Boolean) The flag to enable IPv6
-- `gateway` (String) The IP address of the gateway used by Internet(switch+router)
-- `icon_id` (String) The icon id attached to the Internet(switch+router)
-- `ip_addresses` (List of String) A set of assigned global address to the Internet(switch+router)
-- `ipv6_network_address` (String) The IPv6 network address assigned to the Internet(switch+router)
-- `ipv6_prefix` (String) The network prefix of assigned IPv6 addresses to the Internet(switch+router)
-- `ipv6_prefix_len` (Number) The bit length of IPv6 network prefix for Internet(switch+router)
-- `max_ip_address` (String) Maximum IP address in assigned global addresses to the Internet(switch+router)
-- `min_ip_address` (String) Minimum IP address in assigned global addresses to the Internet(switch+router)
-- `netmask` (Number) The bit length of the subnet assigned to the Internet(switch+router)
+- `gateway` (String) The IP address of the gateway used by Internet(router+switch)
+- `icon_id` (String) The icon id attached to the Internet(router+switch)
+- `ip_addresses` (List of String) A set of assigned global address to the Internet(router+switch)
+- `ipv6_network_address` (String) The IPv6 network address assigned to the Internet(router+switch)
+- `ipv6_prefix` (String) The network prefix of assigned IPv6 addresses to the Internet(router+switch)
+- `ipv6_prefix_len` (Number) The bit length of IPv6 network prefix for Internet(router+switch)
+- `max_ip_address` (String) Maximum IP address in assigned global addresses to the Internet(router+switch)
+- `min_ip_address` (String) Minimum IP address in assigned global addresses to the Internet(router+switch)
+- `netmask` (Number) The bit length of the subnet assigned to the Internet(router+switch)
 - `network_address` (String) The network address assigned to the Switch+Router
-- `server_ids` (List of String) A list of the ID of Servers connected to the Internet(switch+router)
-- `vswitch_id` (String) The id of the vSwitch connected from the Internet(switch+router)
+- `server_ids` (List of String) A list of the ID of Servers connected to the Internet(router+switch)
+- `vswitch_id` (String) The id of the vSwitch connected from the Internet(router+switch)

--- a/docs/data-sources/subnet.md
+++ b/docs/data-sources/subnet.md
@@ -25,8 +25,8 @@ data sakura_subnet "foobar" {
 
 ### Required
 
-- `index` (Number) The index of the subnet in assigned to the Internet(switch+router)
-- `internet_id` (String) The id of the Internet(switch+router) resource that the Subnet belongs
+- `index` (Number) The index of the subnet in assigned to the Internet(router+switch)
+- `internet_id` (String) The id of the Internet(router+switch) resource that the Subnet belongs
 
 ### Optional
 

--- a/docs/resources/internet.md
+++ b/docs/resources/internet.md
@@ -3,12 +3,12 @@
 page_title: "sakura_internet Resource - sakura"
 subcategory: "Networking"
 description: |-
-  Manages an Internet(Switch + Router).
+  Manages an Internet(router+switch).
 ---
 
 # sakura_internet (Resource)
 
-Manages an Internet(Switch + Router).
+Manages an Internet(router+switch).
 
 ## Example Usage
 

--- a/docs/resources/internet.md
+++ b/docs/resources/internet.md
@@ -30,31 +30,31 @@ resource "sakura_internet" "foobar" {
 
 ### Required
 
-- `name` (String) The name of the Internet(switch+router).
+- `name` (String) The name of the Internet(router+switch).
 
 ### Optional
 
 - `band_width` (Number) The bandwidth of the network connected to the Internet in Mbps. `100`/`250`/`500`/`1000`/`1500`/`2000`/`2500`/`3000`/`3500`/`4000`/`4500`/`5000`/`5500`/`6000`/`6500`/`7000`/`7500`/`8000`/`8500`/`9000`/`9500`/`10000`
-- `description` (String) The description of the Internet(switch+router). The length of this value must be in the range [`1`-`512`]
+- `description` (String) The description of the Internet(router+switch). The length of this value must be in the range [`1`-`512`]
 - `enable_ipv6` (Boolean) The flag to enable IPv6
-- `icon_id` (String) The icon id to attach to the Internet(switch+router)
-- `netmask` (Number) The bit length of the subnet assigned to the Internet(switch+router). `26`/`27`/`28`
-- `tags` (Set of String) The tags of the Internet(switch+router).
+- `icon_id` (String) The icon id to attach to the Internet(router+switch)
+- `netmask` (Number) The bit length of the subnet assigned to the Internet(router+switch). `26`/`27`/`28`
+- `tags` (Set of String) The tags of the Internet(router+switch).
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
-- `zone` (String) The name of zone that the Internet(switch+router) will be created (e.g. `is1a`, `tk1a`)
+- `zone` (String) The name of zone that the Internet(router+switch) will be created (e.g. `is1a`, `tk1a`)
 
 ### Read-Only
 
-- `gateway` (String) The IP address of the gateway used by the Internet(switch+router)
-- `id` (String) The ID of the Internet(switch+router).
-- `ip_addresses` (List of String) A set of assigned global address to the Internet(switch+router)
-- `ipv6_network_address` (String) The IPv6 network address assigned to the Internet(switch+router)
-- `ipv6_prefix` (String) The network prefix of assigned IPv6 addresses to the Internet(switch+router)
+- `gateway` (String) The IP address of the gateway used by the Internet(router+switch)
+- `id` (String) The ID of the Internet(router+switch).
+- `ip_addresses` (List of String) A set of assigned global address to the Internet(router+switch)
+- `ipv6_network_address` (String) The IPv6 network address assigned to the Internet(router+switch)
+- `ipv6_prefix` (String) The network prefix of assigned IPv6 addresses to the Internet(router+switch)
 - `ipv6_prefix_len` (Number) The bit length of IPv6 network prefix
-- `max_ip_address` (String) Maximum IP address in assigned global addresses to the Internet(switch+router)
-- `min_ip_address` (String) Minimum IP address in assigned global addresses to the Internet(switch+router)
-- `network_address` (String) The IPv4 network address assigned to the Internet(switch+router)
-- `server_ids` (List of String) A set of the ID of Servers connected to the Internet(switch+router)
+- `max_ip_address` (String) Maximum IP address in assigned global addresses to the Internet(router+switch)
+- `min_ip_address` (String) Minimum IP address in assigned global addresses to the Internet(router+switch)
+- `network_address` (String) The IPv4 network address assigned to the Internet(router+switch)
+- `server_ids` (List of String) A set of the ID of Servers connected to the Internet(router+switch)
 - `vswitch_id` (String) The id of the vSwitch
 
 <a id="nestedatt--timeouts"></a>

--- a/docs/resources/subnet.md
+++ b/docs/resources/subnet.md
@@ -28,7 +28,7 @@ resource "sakura_subnet" "foobar" {
 
 ### Required
 
-- `internet_id` (String) The id of the Internet(switch+router) resource that the Subnet belongs
+- `internet_id` (String) The id of the Internet(router+switch) resource that the Subnet belongs
 - `next_hop` (String) The ip address of the next-hop at the Subnet
 
 ### Optional

--- a/internal/service/internet/data_source.go
+++ b/internal/service/internet/data_source.go
@@ -45,7 +45,7 @@ type internetDataSourceModel struct {
 }
 
 func (d *internetDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resourceName := "Internet(switch+router)"
+	resourceName := "Internet(router+switch)"
 
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/internal/service/internet/data_source.go
+++ b/internal/service/internet/data_source.go
@@ -101,7 +101,7 @@ func (d *internetDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 				Description: desc.Sprintf("The IPv6 network address assigned to the %s", resourceName),
 			},
 		},
-		MarkdownDescription: "Get information about an existing Internet(Switch + Router).",
+		MarkdownDescription: "Get information about an existing Internet(router+switch).",
 	}
 }
 

--- a/internal/service/internet/resource.go
+++ b/internal/service/internet/resource.go
@@ -61,7 +61,7 @@ type internetResourceModel struct {
 }
 
 func (r *internetResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resourceName := "Internet(switch+router)"
+	resourceName := "Internet(router+switch)"
 
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/internal/service/internet/resource.go
+++ b/internal/service/internet/resource.go
@@ -144,7 +144,7 @@ func (r *internetResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 				Create: true, Update: true, Delete: true,
 			}),
 		},
-		MarkdownDescription: "Manages an Internet(Switch + Router).",
+		MarkdownDescription: "Manages an Internet(router+switch).",
 	}
 }
 

--- a/internal/service/subnet/data_source.go
+++ b/internal/service/subnet/data_source.go
@@ -53,14 +53,14 @@ func (d *subnetDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 			"zone": common.SchemaDataSourceZone("Subnet"),
 			"internet_id": schema.StringAttribute{
 				Required:    true,
-				Description: "The id of the Internet(switch+router) resource that the Subnet belongs",
+				Description: "The id of the Internet(router+switch) resource that the Subnet belongs",
 				Validators: []validator.String{
 					sacloudvalidator.SakuraIDValidator(),
 				},
 			},
 			"index": schema.Int64Attribute{
 				Required:    true,
-				Description: "The index of the subnet in assigned to the Internet(switch+router)",
+				Description: "The index of the subnet in assigned to the Internet(router+switch)",
 			},
 			"vswitch_id": common.SchemaDataSourceVSwitchID("Subnet"),
 			"netmask":    common.SchemaDataSourceNetMask("Subnet"),
@@ -109,7 +109,7 @@ func (d *subnetDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 	res, err := internetOp.Read(ctx, zone, internetID)
 	if err != nil {
-		resp.Diagnostics.AddError("Read: API Error", "failed to find Internet(switch+router) for Subnet: "+err.Error())
+		resp.Diagnostics.AddError("Read: API Error", "failed to find Internet(router+switch) for Subnet: "+err.Error())
 		return
 	}
 	if subnetIndex >= len(res.Switch.Subnets) {

--- a/internal/service/subnet/resource.go
+++ b/internal/service/subnet/resource.go
@@ -61,7 +61,7 @@ func (r *subnetResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"zone": common.SchemaResourceZone("Subnet"),
 			"internet_id": schema.StringAttribute{
 				Required:    true,
-				Description: "The id of the Internet(switch+router) resource that the Subnet belongs",
+				Description: "The id of the Internet(router+switch) resource that the Subnet belongs",
 				Validators: []validator.String{
 					sacloudvalidator.SakuraIDValidator(),
 				},
@@ -140,7 +140,7 @@ func (r *subnetResource) Create(ctx context.Context, req resource.CreateRequest,
 	internetOp := iaas.NewInternetOp(r.client)
 	internet, err := internetOp.Read(ctx, zone, internetID)
 	if err != nil {
-		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to read Internet(switch+router)[%s] for Subnet: %s", internetID, err))
+		resp.Diagnostics.AddError("Create: API Error", fmt.Sprintf("failed to read Internet(router+switch)[%s] for Subnet: %s", internetID, err))
 		return
 	}
 

--- a/internal/test/checker.go
+++ b/internal/test/checker.go
@@ -116,7 +116,7 @@ func CheckSakuraInternetDestroy(s *terraform.State) error {
 		zone := rs.Primary.Attributes["zone"]
 		_, err := internetOp.Read(context.Background(), zone, common.SakuraCloudID(rs.Primary.ID))
 		if err == nil {
-			return fmt.Errorf("resource Internet(switch+router)[%s] still exists:", rs.Primary.ID)
+			return fmt.Errorf("resource Internet(router+switch)[%s] still exists:", rs.Primary.ID)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

さくらのドキュメントではルータ+スイッチが正式表記なのでそちらで統一する。

https://manual.sakura.ad.jp/cloud/network/switch/index.html

### ドキュメントの変更は必要ですか？

再生成したのを同梱