### PR TITLE
database: support connect attribute in backup v1 for postgresql 15

### DIFF
--- a/docs/data-sources/database.md
+++ b/docs/data-sources/database.md
@@ -49,6 +49,7 @@ data "sakura_database" "foobar" {
 
 Read-Only:
 
+- `connect` (String) The NFS server address for storing backups (e.g., `nfs://192.0.2.1/export`)
 - `days_of_week` (Set of String) The list of name of days of week that doing backup. This will be in [`sun`/`mon`/`tue`/`wed`/`thu`/`fri`/`sat`]
 - `time` (String) The time to take backup. This will be formatted with `HH:mm`
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -152,6 +152,10 @@ Required:
 - `days_of_week` (Set of String) A list of days of week to backed up. The values in the list must be in [`sun`/`mon`/`tue`/`wed`/`thu`/`fri`/`sat`]
 - `time` (String) The time to take backup. This must be formatted with `HH:mm`
 
+Optional:
+
+- `connect` (String) NFS server address for storing backups (e.g., `nfs://192.0.2.1/export`). This is only available for PostgreSQL 15 or later.
+
 
 <a id="nestedatt--continuous_backup"></a>
 ### Nested Schema for `continuous_backup`

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -154,7 +154,7 @@ Required:
 
 Optional:
 
-- `connect` (String) NFS server address for storing backups (e.g., `nfs://192.0.2.1/export`). This is only available for PostgreSQL 15 or later.
+- `connect` (String) The NFS server address for storing backups (e.g., `nfs://192.0.2.1/export`)
 
 
 <a id="nestedatt--continuous_backup"></a>

--- a/docs/resources/database_read_replica.md
+++ b/docs/resources/database_read_replica.md
@@ -22,8 +22,8 @@ resource "sakura_kms" "foobar" {
 }
 
 resource "sakura_database_read_replica" "foobar" {
-  master_id                 = data.sakura_database.master.id
-  replica_password_wo     = "your-replica-password"
+  master_id           = data.sakura_database.master.id
+  replica_password_wo = "your-replica-password"
   replica_password_wo_version = 1
   network_interface = {
     ip_address = "192.168.11.111"

--- a/examples/resources/sakura_database_read_replica/resource.tf
+++ b/examples/resources/sakura_database_read_replica/resource.tf
@@ -7,8 +7,8 @@ resource "sakura_kms" "foobar" {
 }
 
 resource "sakura_database_read_replica" "foobar" {
-  master_id                 = data.sakura_database.master.id
-  replica_password_wo     = "your-replica-password"
+  master_id           = data.sakura_database.master.id
+  replica_password_wo = "your-replica-password"
   replica_password_wo_version = 1
   network_interface = {
     ip_address = "192.168.11.111"

--- a/internal/service/database/data_source.go
+++ b/internal/service/database/data_source.go
@@ -103,6 +103,10 @@ func (d *databaseDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 						Computed:    true,
 						Description: "The time to take backup. This will be formatted with `HH:mm`",
 					},
+					"connect": schema.StringAttribute{
+						Computed:    true,
+						Description: "The NFS server address for storing backups (e.g., `nfs://192.0.2.1/export`)",
+					},
 				},
 			},
 			"continuous_backup": schema.SingleNestedAttribute{

--- a/internal/service/database/data_source_test.go
+++ b/internal/service/database/data_source_test.go
@@ -33,6 +33,8 @@ func TestAccSakuraDataSourceDatabase_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "backup.days_of_week.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "backup.days_of_week.0", "mon"),
 					resource.TestCheckResourceAttr(resourceName, "backup.days_of_week.1", "tue"),
+					resource.TestCheckResourceAttr(resourceName, "backup.time", "00:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup.connect", "nfs://192.168.0.31/export"),
 				),
 			},
 		},
@@ -63,6 +65,7 @@ resource "sakura_database" "foobar" {
   backup = {
     days_of_week = ["mon", "tue"]
     time         = "00:00"
+    connect      = "nfs://192.168.0.31/export"
   }
 }
 

--- a/internal/service/database/model.go
+++ b/internal/service/database/model.go
@@ -47,12 +47,14 @@ type databaseNetworkInterfaceModel struct {
 type databaseBackupModel struct {
 	DaysOfWeek types.Set    `tfsdk:"days_of_week"`
 	Time       types.String `tfsdk:"time"`
+	Connect    types.String `tfsdk:"connect"`
 }
 
 func (m databaseBackupModel) AttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"days_of_week": types.SetType{ElemType: types.StringType},
 		"time":         types.StringType,
+		"connect":      types.StringType,
 	}
 }
 
@@ -128,6 +130,9 @@ func flattenDatabaseBackupSetting(db *iaas.Database) types.Object {
 		m := databaseBackupModel{
 			Time:       types.StringValue(db.BackupSetting.Time),
 			DaysOfWeek: common.FlattenBackupDaysOfWeek(db.BackupSetting.DayOfWeek),
+		}
+		if db.BackupSetting.Connect != "" {
+			m.Connect = types.StringValue(db.BackupSetting.Connect)
 		}
 		value, diags := types.ObjectValueFrom(context.Background(), m.AttributeTypes(), m)
 		if diags.HasError() {

--- a/internal/service/database/model.go
+++ b/internal/service/database/model.go
@@ -130,9 +130,7 @@ func flattenDatabaseBackupSetting(db *iaas.Database) types.Object {
 		m := databaseBackupModel{
 			Time:       types.StringValue(db.BackupSetting.Time),
 			DaysOfWeek: common.FlattenBackupDaysOfWeek(db.BackupSetting.DayOfWeek),
-		}
-		if db.BackupSetting.Connect != "" {
-			m.Connect = types.StringValue(db.BackupSetting.Connect)
+			Connect:    types.StringValue(db.BackupSetting.Connect),
 		}
 		value, diags := types.ObjectValueFrom(context.Background(), m.AttributeTypes(), m)
 		if diags.HasError() {

--- a/internal/service/database/resource.go
+++ b/internal/service/database/resource.go
@@ -224,7 +224,7 @@ func (r *databaseResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 					},
 					"connect": schema.StringAttribute{
 						Optional:    true,
-						Description: "NFS server address for storing backups (e.g., `nfs://192.0.2.1/export`). This is only available for PostgreSQL 15 or later.",
+						Description: "The NFS server address for storing backups (e.g., `nfs://192.0.2.1/export`)",
 					},
 				},
 			},

--- a/internal/service/database/resource.go
+++ b/internal/service/database/resource.go
@@ -224,6 +224,7 @@ func (r *databaseResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 					},
 					"connect": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
 						Description: "The NFS server address for storing backups (e.g., `nfs://192.0.2.1/export`)",
 					},
 				},

--- a/internal/service/database/resource.go
+++ b/internal/service/database/resource.go
@@ -162,7 +162,7 @@ func (r *databaseResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 			"network_interface": schema.SingleNestedAttribute{
 				Required: true,
 				Attributes: map[string]schema.Attribute{
-					"vswitch_id": common.SchemaResourceSwitchID("Database"),
+					"vswitch_id": common.SchemaResourceVSwitchID("Database"),
 					"ip_address": schema.StringAttribute{
 						Required:    true,
 						Description: "The IP address to assign to the Database",
@@ -221,6 +221,10 @@ func (r *databaseResource) Schema(ctx context.Context, _ resource.SchemaRequest,
 						Validators: []validator.String{
 							sacloudvalidator.BackupTimeValidator(),
 						},
+					},
+					"connect": schema.StringAttribute{
+						Optional:    true,
+						Description: "NFS server address for storing backups (e.g., `nfs://192.0.2.1/export`). This is only available for PostgreSQL 15 or later.",
 					},
 				},
 			},
@@ -499,9 +503,11 @@ func expandDatabaseBackupSetting(model *databaseResourceModel) *iaas.DatabaseSet
 
 	backupTime := backup.Time.ValueString()
 	backupDaysOfWeek := common.ExpandBackupDaysOfWeek(backup.DaysOfWeek)
+	backupConnect := backup.Connect.ValueString()
 	return &iaas.DatabaseSettingBackup{
 		Time:      backupTime,
 		DayOfWeek: backupDaysOfWeek,
+		Connect:   backupConnect,
 		Rotate:    8,
 	}
 }

--- a/internal/service/database/resource_test.go
+++ b/internal/service/database/resource_test.go
@@ -60,6 +60,7 @@ func TestAccSakuraDatabase_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "backup.days_of_week.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "backup.days_of_week.0", "mon"),
 					resource.TestCheckResourceAttr(resourceName, "backup.days_of_week.1", "tue"),
+					resource.TestCheckResourceAttr(resourceName, "backup.connect", "file:///backup"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.max_connections", "100"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.event_scheduler", "ON"),


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

https://cloud.sakura.ad.jp/news/2026/07/23/db-appliance-postgresql-15/ のリリースからbackup v1でもconnectをサポートしたので対応する。<s>他では指定しないのでOptionalとして実装。</s>
examplesでインデントのおかしいのがあったので一緒に修正。

### ドキュメントの変更は必要ですか？

同梱済み