### PR TITLE
Set null to public_network_interface.aliases to avoid conversion error. fix #306

### DIFF
--- a/internal/service/vpn_router/model.go
+++ b/internal/service/vpn_router/model.go
@@ -300,6 +300,8 @@ func flattenVPNRouterPublicNetworkInterface(vpcRouter *iaas.VPCRouter) types.Obj
 	aliases := flattenVPNRouterIPAliases(vpcRouter)
 	if len(aliases) > 0 {
 		m.Aliases = common.StringsToTlist(aliases)
+	} else {
+		m.Aliases = types.ListNull(types.StringType)
 	}
 	value, diags := types.ObjectValueFrom(context.Background(), m.AttributeTypes(), m)
 	if diags.HasError() {

--- a/internal/service/vpn_router/resource_test.go
+++ b/internal/service/vpn_router/resource_test.go
@@ -366,6 +366,38 @@ func TestAccSakuraVPNRouter_WOFull(t *testing.T) {
 	})
 }
 
+// test for https://github.com/sacloud/terraform-provider-sakura/issues/306
+func TestAccSakuraVPNRouter_Issue306(t *testing.T) {
+	resourceName := "sakura_vpn_router.foobar"
+	rand := test.RandomName()
+
+	var vpcRouter iaas.VPCRouter
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			test.CheckSakuraInternetDestroy,
+			test.CheckSakuravSwitchDestroy,
+			testCheckSakuraVPNRouterDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraVPNRouter_issue306, rand),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraVPNRouterExists(resourceName, &vpcRouter),
+					resource.TestCheckResourceAttr(resourceName, "name", rand),
+					resource.TestCheckResourceAttr(resourceName, "plan", "premium"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_netmask"),
+					resource.TestCheckResourceAttr(resourceName, "private_network_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "public_network_interface.vrid", "1"),
+					resource.TestCheckNoResourceAttr(resourceName, "public_network_interface.aliases"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckSakuraVPNRouterExists(n string, vpcRouter *iaas.VPCRouter) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -842,5 +874,36 @@ resource "sakura_vpn_router" "foobar" {
 var testAccSakuraVPNRouter_import = `
 resource "sakura_vpn_router" "foobar" {
   name = "{{ .arg0 }}"
+}
+`
+
+var testAccSakuraVPNRouter_issue306 = `
+resource "sakura_internet" "foobar" {
+  name = "{{ .arg0 }}"
+}
+resource "sakura_vswitch" "foobar" {
+  name = "{{ .arg0 }}"
+}
+
+resource "sakura_vpn_router" "foobar" {
+  name = "{{ .arg0 }}"
+  plan = "premium"
+  internet_connection = true
+
+  public_network_interface = {
+    vswitch_id   = sakura_internet.foobar.vswitch_id
+    vip          = sakura_internet.foobar.ip_addresses[0]
+    ip_addresses = [sakura_internet.foobar.ip_addresses[1], sakura_internet.foobar.ip_addresses[2]]
+    vrid         = 1
+    # No aliases
+  }
+
+  private_network_interface = [{
+    index        = 1
+    vswitch_id   = sakura_vswitch.foobar.id
+    vip          = "192.168.11.1"
+    ip_addresses = ["192.168.11.2", "192.168.11.3"]
+    netmask      = 24
+  }]
 }
 `

--- a/internal/service/vpn_router/structure.go
+++ b/internal/service/vpn_router/structure.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/defaults"
 	iaastypes "github.com/sacloud/iaas-api-go/types"
@@ -51,6 +52,10 @@ func expandVPNRouterNICSetting(model *vpnRouterResourceModel) builder.NICSetting
 		return &builder.StandardNICSetting{}
 	default:
 		nic := expandVPNRouterPublicNetworkInterface(model)
+		if nic == nil {
+			tflog.Warn(context.Background(), fmt.Sprintf("Can't expand VPN Router public_network_interface. This is something wrong with the configuration or broken state"))
+			return &builder.PremiumNICSetting{}
+		}
 		return &builder.PremiumNICSetting{
 			SwitchID:         nic.switchID,
 			IPAddresses:      nic.ipAddresses,


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #306

### このPRはどういう変更を行いますか？

public_network_interface.aliasesが設定されていない場合にUnknownになり、オブジェクトの変換に失敗した結果Stateが壊れる問題を修正。Optional属性なので、ちゃんとnullを設定する必要がある。
また今後に備えてnilチェックも追加。ただしこれは不具合以外では起きないルートとなっている。

### ドキュメントの変更は必要ですか？

必要無し。