### PR TITLE
enhanced_lb_acme: Support update action. also fix #305

### DIFF
--- a/docs/resources/enhanced_lb_acme.md
+++ b/docs/resources/enhanced_lb_acme.md
@@ -56,6 +56,7 @@ Optional:
 
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 
 
 <a id="nestedatt--certificate"></a>

--- a/internal/service/enhanced_lb/resource_acme.go
+++ b/internal/service/enhanced_lb/resource_acme.go
@@ -147,7 +147,7 @@ func (r *enhancedLBACMEResource) Schema(ctx context.Context, _ resource.SchemaRe
 				},
 			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
-				Create: true, Delete: true,
+				Create: true, Update: true, Delete: true,
 			}),
 		},
 		MarkdownDescription: "Manages an Enhanced Load Balancer's ACME",
@@ -316,6 +316,15 @@ func (r *enhancedLBACMEResource) Update(ctx context.Context, req resource.Update
 		resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to update setting Enhanced LB[%s] ACME: %s", elbID, err))
 		return
 	}
+
+	if !plan.AcceptTOS.ValueBool() {
+		// ACMEを無効化した場合は、証明書を再発行する必要がないので、ここで終了する
+		plan.ID = state.ID
+		plan.Certificate = types.ObjectNull(enhancedLBCertificateModel{}.AttributeTypes())
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+		return
+	}
+
 	if err := elbOp.RenewLetsEncryptCert(ctx, elb.ID); err != nil {
 		resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to renew ACME Certificates at Enhanced LB[%s]: %s", elb.ID, err))
 		return

--- a/internal/service/enhanced_lb/resource_acme.go
+++ b/internal/service/enhanced_lb/resource_acme.go
@@ -12,16 +12,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/terraform-provider-sakura/internal/common"
+	"github.com/sacloud/terraform-provider-sakura/internal/common/utils"
 	sacloudvalidator "github.com/sacloud/terraform-provider-sakura/internal/validator"
 )
 
@@ -80,40 +78,25 @@ func (r *enhancedLBACMEResource) Schema(ctx context.Context, _ resource.SchemaRe
 			"accept_tos": schema.BoolAttribute{
 				Required:    true,
 				Description: "The flag to accept the current Let's Encrypt terms of service(see: https://letsencrypt.org/repository/). This must be set `true` explicitly",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
 			},
 			"common_name": schema.StringAttribute{
 				Required:    true,
 				Description: "The FQDN used by ACME. This must set resolvable value",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"subject_alt_names": schema.SetAttribute{
 				Optional:    true,
 				ElementType: types.StringType,
 				Description: "The Subject alternative names used by ACME",
-				PlanModifiers: []planmodifier.Set{
-					setplanmodifier.RequiresReplaceIfConfigured(),
-				},
 			},
 			"update_delay_sec": schema.Int32Attribute{
 				Optional:    true,
 				Description: "The wait time in seconds. This typically used for waiting for a DNS propagation",
-				PlanModifiers: []planmodifier.Int32{
-					int32planmodifier.RequiresReplaceIfConfigured(),
-				},
 			},
 			"get_certificates_timeout_sec": schema.Int32Attribute{
 				Optional:    true,
 				Computed:    true,
 				Description: "The timeout in seconds for the certificate acquisition to complete",
 				Default:     int32default.StaticInt32(120),
-				PlanModifiers: []planmodifier.Int32{
-					int32planmodifier.RequiresReplaceIfConfigured(),
-				},
 			},
 			"certificate": schema.SingleNestedAttribute{
 				Computed:    true,
@@ -257,7 +240,7 @@ func (r *enhancedLBACMEResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	elb := getELB(ctx, r.client, state.EnhancedLBID.ValueString(), &resp.State, &resp.Diagnostics)
+	elb := getELB(ctx, r.client, state.ID.ValueString(), &resp.State, &resp.Diagnostics)
 	if elb == nil {
 		return
 	}
@@ -270,7 +253,84 @@ func (r *enhancedLBACMEResource) Read(ctx context.Context, req resource.ReadRequ
 }
 
 func (r *enhancedLBACMEResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	resp.Diagnostics.AddError("Update Error", "updating Enhanced LB ACME is not supported. To change the attributes, please delete and recreate the resource.")
+	var plan, state enhancedLBACMEResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.AcceptTOS.Equal(state.AcceptTOS) &&
+		plan.CommonName.Equal(state.CommonName) &&
+		plan.SubjectAltNames.Equal(state.SubjectAltNames) {
+		plan.ID = state.ID
+		plan.Certificate = state.Certificate
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+		return
+	}
+
+	ctx, cancel := common.SetupTimeoutUpdate(ctx, plan.Timeouts, common.Timeout20min)
+	defer cancel()
+
+	elbID := state.EnhancedLBID.ValueString()
+	common.SakuraMutexKV.Lock(elbID)
+	defer common.SakuraMutexKV.Unlock(elbID)
+
+	elb := getELB(ctx, r.client, elbID, &resp.State, &resp.Diagnostics)
+	if elb == nil {
+		return
+	}
+
+	le := &iaas.ProxyLBACMESetting{Enabled: false}
+	if plan.AcceptTOS.ValueBool() {
+		le = &iaas.ProxyLBACMESetting{
+			Enabled:         true,
+			CommonName:      plan.CommonName.ValueString(),
+			SubjectAltNames: common.TsetToStrings(plan.SubjectAltNames),
+		}
+	}
+
+	if plan.UpdateDelaySec.ValueInt32() > 0 {
+		time.Sleep(time.Duration(plan.UpdateDelaySec.ValueInt32()) * time.Second)
+	}
+
+	elbOp := iaas.NewProxyLBOp(r.client)
+	elb, err := elbOp.UpdateSettings(ctx, elb.ID, &iaas.ProxyLBUpdateSettingsRequest{
+		HealthCheck:          elb.HealthCheck,
+		SorryServer:          elb.SorryServer,
+		BindPorts:            elb.BindPorts,
+		Servers:              elb.Servers,
+		Rules:                elb.Rules,
+		LetsEncrypt:          le,
+		StickySession:        elb.StickySession,
+		Timeout:              elb.Timeout,
+		Gzip:                 elb.Gzip,
+		BackendHttpKeepAlive: elb.BackendHttpKeepAlive,
+		ProxyProtocol:        elb.ProxyProtocol,
+		Syslog:               elb.Syslog,
+		OriginGuard:          elb.OriginGuard,
+		StrictRule:           elb.StrictRule,
+		SettingsHash:         elb.SettingsHash,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to update setting Enhanced LB[%s] ACME: %s", elbID, err))
+		return
+	}
+	if err := elbOp.RenewLetsEncryptCert(ctx, elb.ID); err != nil {
+		resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to renew ACME Certificates at Enhanced LB[%s]: %s", elb.ID, err))
+		return
+	}
+
+	if err := waitForProxyLBCertAcquisitionFW(ctx, r.client, elb.ID.String(), plan.GetCertificatesTimeoutSec.ValueInt32()); err != nil {
+		resp.Diagnostics.AddError("Update: API Error", fmt.Sprintf("failed to wait for ACME certificate acquisition of Enhanced LB[%s]: %s", elb.ID, err))
+		return
+	}
+
+	if err := plan.updateState(ctx, r.client, elb); err != nil {
+		resp.Diagnostics.AddError("Update: Terraform Error", fmt.Sprintf("failed to update state for Enhanced LB[%s] ACME: %s", elb.ID, err))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *enhancedLBACMEResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -326,7 +386,17 @@ func (model *enhancedLBACMEResourceModel) updateState(ctx context.Context, clien
 	}
 
 	model.ID = types.StringValue(data.ID.String())
+	model.EnhancedLBID = types.StringValue(data.ID.String())
 	model.Certificate = flattenEnhancedLBCerts(certs, model.Certificate)
+	model.CommonName = types.StringValue(data.LetsEncrypt.CommonName)
+	if len(data.LetsEncrypt.SubjectAltNames) == 0 {
+		model.SubjectAltNames = types.SetNull(types.StringType)
+	} else {
+		model.SubjectAltNames = common.StringsToTset(data.LetsEncrypt.SubjectAltNames)
+	}
+	if !utils.IsKnown(model.AcceptTOS) { // for Import
+		model.AcceptTOS = types.BoolValue(data.LetsEncrypt.Enabled)
+	}
 
 	return nil
 }

--- a/internal/service/enhanced_lb/resource_acme_test.go
+++ b/internal/service/enhanced_lb/resource_acme_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/terraform-provider-sakura/internal/test"
 )
@@ -91,7 +92,58 @@ func TestAccSakuraEnhancedLBACME_basic(t *testing.T) {
 	})
 }
 
-var testAccSakuraEnhancedLBACME_basic = `
+func TestAccImportSakuraEnhancedLBACME_basic(t *testing.T) {
+	test.SkipIfEnvIsNotSet(t, envEnhancedLBACMEDomain)
+
+	rand := test.RandomName()
+	subDomain := "acme-accimporttest1" + test.RandStringFromCharSet(5, "")
+	elbDomain := os.Getenv(envEnhancedLBACMEDomain)
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state: %#v", s)
+		}
+		expects := map[string]string{
+			"accept_tos":          "true",
+			"common_name":         subDomain + "." + elbDomain,
+			"subject_alt_names.0": "acme-accimporttest2" + "." + elbDomain,
+		}
+
+		if err := test.CompareStateMulti(s[0], expects); err != nil {
+			return err
+		}
+		return test.StateNotEmptyMulti(s[0], "enhanced_lb_id")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { test.AccPreCheck(t) },
+		ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			test.CheckSakuraDiskDestroy,
+			test.CheckSakuraDNSRecordDestroy,
+			testCheckSakuraEnhancedLBDestroy,
+			test.CheckSakuraServerDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: test.BuildConfigWithArgs(testAccImportSakuraEnhancedLBACME_basic, rand, elbDomain, subDomain),
+			},
+			{
+				ResourceName:      "sakura_enhanced_lb_acme.foobar",
+				ImportState:       true,
+				ImportStateCheck:  checkFn,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"get_certificates_timeout_sec",
+					"timeouts",
+					"update_delay_sec",
+				},
+			},
+		},
+	})
+}
+
+var testAccSakuraEnhancedLBACME_base = `
 data "sakura_archive" "ubuntu" {
   os_type = "ubuntu"
 }
@@ -151,7 +203,9 @@ resource "sakura_enhanced_lb" "foobar" {
     enabled = true
   }
 }
+`
 
+var testAccSakuraEnhancedLBACME_baseWithDNS = testAccSakuraEnhancedLBACME_base + `
 data "sakura_dns" "zone" {
   name = "{{ .arg1 }}"
 }
@@ -191,7 +245,9 @@ resource "sakura_dns_record" "record5" {
   value  = "${sakura_enhanced_lb.foobar.fqdn}."
   ttl    = 10
 }
+`
 
+var testAccSakuraEnhancedLBACME_basic = testAccSakuraEnhancedLBACME_baseWithDNS + `
 resource "sakura_enhanced_lb_acme" "foobar" {
   enhanced_lb_id               = sakura_enhanced_lb.foobar.id
   accept_tos                   = true
@@ -204,67 +260,20 @@ resource "sakura_enhanced_lb_acme" "foobar" {
 }
 `
 
-var testAccSakuraEnhancedLBACME_update = `
-data "sakura_archive" "ubuntu" {
-  os_type = "ubuntu"
+var testAccSakuraEnhancedLBACME_update = testAccSakuraEnhancedLBACME_baseWithDNS + `
+resource "sakura_enhanced_lb_acme" "foobar" {
+  enhanced_lb_id               = sakura_enhanced_lb.foobar.id
+  accept_tos                   = true
+  common_name                  = "{{ .arg3 }}.{{ .arg1 }}"
+  subject_alt_names            = ["acme-acctest5.{{ .arg1 }}"]
+  update_delay_sec             = 20
+  get_certificates_timeout_sec = 300
+
+  depends_on = [sakura_dns_record.record, sakura_dns_record.record2, sakura_dns_record.record3, sakura_dns_record.record4, sakura_dns_record.record5]
 }
+`
 
-resource "sakura_disk" "foobar" {
-  name              = "{{ .arg0 }}"
-  source_archive_id = data.sakura_archive.ubuntu.id
-}
-
-resource "sakura_server" "foobar" {
-  name  = "{{ .arg0 }}"
-  disks = [sakura_disk.foobar.id]
-  network_interface = [{
-    upstream = "shared"
-  }]
-}
-
-resource "sakura_enhanced_lb" "foobar" {
-  name           = "{{ .arg0 }}"
-  plan           = 100
-  vip_failover   = true
-  gzip           = true
-  proxy_protocol = true
-
-  backend_http_keep_alive = "aggressive"
-
-  health_check = {
-    protocol    = "http"
-    delay_loop  = 10
-    host_header = "usacloud.jp"
-    path        = "/"
-  }
-  bind_port = [{
-    proxy_mode = "http"
-    port       = 80
-  },
-  {
-    proxy_mode = "https"
-    port       = 443
-  }]
-  server = [{
-    ip_address = sakura_server.foobar.ip_address
-    port       = 80
-    group      = "group1"
-  }]
-  rule = [{
-    host  = "www.usacloud.com"
-    path  = "/"
-    group = "group1"
-  }]
-
-  origin_guard = {
-    token = "abcdefgh"
-  }
-
-  strict_rule = {
-    enabled = true
-  }
-}
-
+var testAccImportSakuraEnhancedLBACME_basic = testAccSakuraEnhancedLBACME_base + `
 data "sakura_dns" "zone" {
   name = "{{ .arg1 }}"
 }
@@ -278,41 +287,20 @@ resource "sakura_dns_record" "record" {
 }
 resource "sakura_dns_record" "record2" {
   dns_id = data.sakura_dns.zone.id
-  name   = "acme-acctest2"
-  type   = "CNAME"
-  value  = "${sakura_enhanced_lb.foobar.fqdn}."
-  ttl    = 10
-}
-resource "sakura_dns_record" "record3" {
-  dns_id = data.sakura_dns.zone.id
-  name   = "acme-acctest3"
-  type   = "CNAME"
-  value  = "${sakura_enhanced_lb.foobar.fqdn}."
-  ttl    = 10
-}
-resource "sakura_dns_record" "record4" {
-  dns_id = data.sakura_dns.zone.id
-  name   = "{{ .arg3 }}"
-  type   = "CNAME"
-  value  = "${sakura_enhanced_lb.foobar.fqdn}."
-  ttl    = 10
-}
-resource "sakura_dns_record" "record5" {
-  dns_id = data.sakura_dns.zone.id
-  name   = "acme-acctest5"
+  name   = "acme-accimporttest2"
   type   = "CNAME"
   value  = "${sakura_enhanced_lb.foobar.fqdn}."
   ttl    = 10
 }
 
 resource "sakura_enhanced_lb_acme" "foobar" {
-  enhanced_lb_id               = sakura_enhanced_lb.foobar.id
-  accept_tos                   = true
-  common_name                  = "{{ .arg3 }}.{{ .arg1 }}"
-  subject_alt_names            = ["acme-acctest5.{{ .arg1 }}"]
-  update_delay_sec             = 20
+  enhanced_lb_id    = sakura_enhanced_lb.foobar.id
+  accept_tos        = true
+  common_name       = "{{ .arg2 }}.{{ .arg1 }}"
+  subject_alt_names = ["acme-accimporttest2.{{ .arg1 }}"]
+  update_delay_sec  = 120
   get_certificates_timeout_sec = 300
 
-  depends_on = [sakura_dns_record.record, sakura_dns_record.record2, sakura_dns_record.record3, sakura_dns_record.record4, sakura_dns_record.record5]
+  depends_on = [sakura_dns_record.record, sakura_dns_record.record2]
 }
 `

--- a/internal/service/enhanced_lb/resource_acme_test.go
+++ b/internal/service/enhanced_lb/resource_acme_test.go
@@ -24,6 +24,7 @@ func TestAccSakuraEnhancedLBACME_basic(t *testing.T) {
 
 	rand := test.RandomName()
 	subDomain := "acme-acctest1" + test.RandStringFromCharSet(5, "")
+	subDomain2 := "acme-acctest4" + test.RandStringFromCharSet(5, "")
 
 	elbDomain = os.Getenv(envEnhancedLBACMEDomain)
 
@@ -40,7 +41,7 @@ func TestAccSakuraEnhancedLBACME_basic(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraEnhancedLBACME_basic, rand, elbDomain, subDomain),
+				Config: test.BuildConfigWithArgs(testAccSakuraEnhancedLBACME_basic, rand, elbDomain, subDomain, subDomain2),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckSakuraEnhancedLBExists("sakura_enhanced_lb.foobar", &elb),
 					resource.TestCheckResourceAttr("sakura_enhanced_lb.foobar", "gzip", "true"),
@@ -50,6 +51,10 @@ func TestAccSakuraEnhancedLBACME_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("sakura_enhanced_lb.foobar", "origin_guard.token", "abcdefgh"),
 					resource.TestCheckResourceAttr("sakura_enhanced_lb.foobar", "strict_rule.enabled", "true"),
 
+					resource.TestCheckResourceAttrPair(resourceName, "enhanced_lb_id", "sakura_enhanced_lb.foobar", "id"),
+					resource.TestCheckResourceAttr(resourceName, "accept_tos", "true"),
+					resource.TestCheckResourceAttr(resourceName, "update_delay_sec", "120"),
+					resource.TestCheckResourceAttr(resourceName, "get_certificates_timeout_sec", "300"),
 					resource.TestCheckResourceAttr(resourceName, "certificate.common_name", subDomain+"."+elbDomain),
 					resource.TestCheckResourceAttr(resourceName, "certificate.subject_alt_names",
 						fmt.Sprintf("%s.%s, acme-acctest2.%s, acme-acctest3.%s", subDomain, elbDomain, elbDomain, elbDomain),
@@ -58,7 +63,7 @@ func TestAccSakuraEnhancedLBACME_basic(t *testing.T) {
 			},
 			// State refresh is required to evaluate sakura_enhanced_lb.foobar.certificate.*
 			{
-				Config: test.BuildConfigWithArgs(testAccSakuraEnhancedLBACME_basic, rand, elbDomain, subDomain),
+				Config: test.BuildConfigWithArgs(testAccSakuraEnhancedLBACME_basic, rand, elbDomain, subDomain, subDomain2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sakura_enhanced_lb.foobar", "certificate.common_name", subDomain+"."+elbDomain),
 					resource.TestCheckResourceAttr("sakura_enhanced_lb.foobar", "certificate.subject_alt_names",
@@ -66,11 +71,44 @@ func TestAccSakuraEnhancedLBACME_basic(t *testing.T) {
 					),
 				),
 			},
+			{
+				Config: test.BuildConfigWithArgs(testAccSakuraEnhancedLBACME_update, rand, elbDomain, subDomain, subDomain2),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckSakuraEnhancedLBExists("sakura_enhanced_lb.foobar", &elb),
+					resource.TestCheckResourceAttr("sakura_enhanced_lb.foobar", "origin_guard.token", "abcdefgh"),
+
+					resource.TestCheckResourceAttrPair(resourceName, "enhanced_lb_id", "sakura_enhanced_lb.foobar", "id"),
+					resource.TestCheckResourceAttr(resourceName, "update_delay_sec", "20"),
+					/* 反映に時間がかかるため、すぐのチェックでは古いCertificateが返ってくるので、コメントアウト
+					resource.TestCheckResourceAttr(resourceName, "certificate.common_name", subDomain2+"."+elbDomain),
+					resource.TestCheckResourceAttr(resourceName, "certificate.subject_alt_names",
+						fmt.Sprintf("%s.%s, acme-acctest5.%s", subDomain2, elbDomain, elbDomain),
+					),
+					*/
+				),
+			},
 		},
 	})
 }
 
 var testAccSakuraEnhancedLBACME_basic = `
+data "sakura_archive" "ubuntu" {
+  os_type = "ubuntu"
+}
+
+resource "sakura_disk" "foobar" {
+  name              = "{{ .arg0 }}"
+  source_archive_id = data.sakura_archive.ubuntu.id
+}
+
+resource "sakura_server" "foobar" {
+  name  = "{{ .arg0 }}"
+  disks = [sakura_disk.foobar.id]
+  network_interface = [{
+    upstream = "shared"
+  }]
+}
+
 resource "sakura_enhanced_lb" "foobar" {
   name           = "{{ .arg0 }}"
   plan           = 100
@@ -114,34 +152,8 @@ resource "sakura_enhanced_lb" "foobar" {
   }
 }
 
-resource "sakura_enhanced_lb_acme" "foobar" {
-  enhanced_lb_id               = sakura_enhanced_lb.foobar.id
-  accept_tos                   = true
-  common_name                  = "{{ .arg2 }}.{{ .arg1 }}"
-  subject_alt_names            = ["acme-acctest2.{{ .arg1 }}", "acme-acctest3.{{ .arg1 }}"]
-  update_delay_sec             = 120
-  get_certificates_timeout_sec = 300
-}
-
-data "sakura_archive" "ubuntu" {
-  os_type = "ubuntu"
-}
-
-resource "sakura_disk" "foobar" {
-  name              = "{{ .arg0 }}"
-  source_archive_id = data.sakura_archive.ubuntu.id
-}
-
-resource "sakura_server" "foobar" {
-  name  = "{{ .arg0 }}"
-  disks = [sakura_disk.foobar.id]
-  network_interface = [{
-    upstream = "shared"
-  }]
-}
-
 data "sakura_dns" "zone" {
-    name = "{{ .arg1 }}"
+  name = "{{ .arg1 }}"
 }
 
 resource "sakura_dns_record" "record" {
@@ -164,5 +176,143 @@ resource "sakura_dns_record" "record3" {
   type   = "CNAME"
   value  = "${sakura_enhanced_lb.foobar.fqdn}."
   ttl    = 10
+}
+resource "sakura_dns_record" "record4" {
+  dns_id = data.sakura_dns.zone.id
+  name   = "{{ .arg3 }}"
+  type   = "CNAME"
+  value  = "${sakura_enhanced_lb.foobar.fqdn}."
+  ttl    = 10
+}
+resource "sakura_dns_record" "record5" {
+  dns_id = data.sakura_dns.zone.id
+  name   = "acme-acctest5"
+  type   = "CNAME"
+  value  = "${sakura_enhanced_lb.foobar.fqdn}."
+  ttl    = 10
+}
+
+resource "sakura_enhanced_lb_acme" "foobar" {
+  enhanced_lb_id               = sakura_enhanced_lb.foobar.id
+  accept_tos                   = true
+  common_name                  = "{{ .arg2 }}.{{ .arg1 }}"
+  subject_alt_names            = ["acme-acctest2.{{ .arg1 }}", "acme-acctest3.{{ .arg1 }}"]
+  update_delay_sec             = 120
+  get_certificates_timeout_sec = 300
+
+  depends_on = [sakura_dns_record.record, sakura_dns_record.record2, sakura_dns_record.record3, sakura_dns_record.record4, sakura_dns_record.record5]
+}
+`
+
+var testAccSakuraEnhancedLBACME_update = `
+data "sakura_archive" "ubuntu" {
+  os_type = "ubuntu"
+}
+
+resource "sakura_disk" "foobar" {
+  name              = "{{ .arg0 }}"
+  source_archive_id = data.sakura_archive.ubuntu.id
+}
+
+resource "sakura_server" "foobar" {
+  name  = "{{ .arg0 }}"
+  disks = [sakura_disk.foobar.id]
+  network_interface = [{
+    upstream = "shared"
+  }]
+}
+
+resource "sakura_enhanced_lb" "foobar" {
+  name           = "{{ .arg0 }}"
+  plan           = 100
+  vip_failover   = true
+  gzip           = true
+  proxy_protocol = true
+
+  backend_http_keep_alive = "aggressive"
+
+  health_check = {
+    protocol    = "http"
+    delay_loop  = 10
+    host_header = "usacloud.jp"
+    path        = "/"
+  }
+  bind_port = [{
+    proxy_mode = "http"
+    port       = 80
+  },
+  {
+    proxy_mode = "https"
+    port       = 443
+  }]
+  server = [{
+    ip_address = sakura_server.foobar.ip_address
+    port       = 80
+    group      = "group1"
+  }]
+  rule = [{
+    host  = "www.usacloud.com"
+    path  = "/"
+    group = "group1"
+  }]
+
+  origin_guard = {
+    token = "abcdefgh"
+  }
+
+  strict_rule = {
+    enabled = true
+  }
+}
+
+data "sakura_dns" "zone" {
+  name = "{{ .arg1 }}"
+}
+
+resource "sakura_dns_record" "record" {
+  dns_id = data.sakura_dns.zone.id
+  name   = "{{ .arg2 }}"
+  type   = "CNAME"
+  value  = "${sakura_enhanced_lb.foobar.fqdn}."
+  ttl    = 10
+}
+resource "sakura_dns_record" "record2" {
+  dns_id = data.sakura_dns.zone.id
+  name   = "acme-acctest2"
+  type   = "CNAME"
+  value  = "${sakura_enhanced_lb.foobar.fqdn}."
+  ttl    = 10
+}
+resource "sakura_dns_record" "record3" {
+  dns_id = data.sakura_dns.zone.id
+  name   = "acme-acctest3"
+  type   = "CNAME"
+  value  = "${sakura_enhanced_lb.foobar.fqdn}."
+  ttl    = 10
+}
+resource "sakura_dns_record" "record4" {
+  dns_id = data.sakura_dns.zone.id
+  name   = "{{ .arg3 }}"
+  type   = "CNAME"
+  value  = "${sakura_enhanced_lb.foobar.fqdn}."
+  ttl    = 10
+}
+resource "sakura_dns_record" "record5" {
+  dns_id = data.sakura_dns.zone.id
+  name   = "acme-acctest5"
+  type   = "CNAME"
+  value  = "${sakura_enhanced_lb.foobar.fqdn}."
+  ttl    = 10
+}
+
+resource "sakura_enhanced_lb_acme" "foobar" {
+  enhanced_lb_id               = sakura_enhanced_lb.foobar.id
+  accept_tos                   = true
+  common_name                  = "{{ .arg3 }}.{{ .arg1 }}"
+  subject_alt_names            = ["acme-acctest5.{{ .arg1 }}"]
+  update_delay_sec             = 20
+  get_certificates_timeout_sec = 300
+
+  depends_on = [sakura_dns_record.record, sakura_dns_record.record2, sakura_dns_record.record3, sakura_dns_record.record4, sakura_dns_record.record5]
 }
 `


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #305

### このPRはどういう変更を行いますか？

Another try of https://github.com/sacloud/terraform-provider-sakura/pull/314.
UpdateをサポートしてRequiresReplace系を削除することでimportをIDのみでできるように。

テストではGetCertificatesの値が即座に反映されないためコメントアウトしているが、ここをチェックするには独自にwaitするしかない？

### ドキュメントの変更は必要ですか？

おそらくなし？