### PR TITLE
vpn_router: Remove planmodifier from updatable attributes and ...

### DIFF
--- a/internal/service/vpn_router/resource.go
+++ b/internal/service/vpn_router/resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -132,9 +131,6 @@ func (d *vpnRouterResource) Schema(ctx context.Context, _ resource.SchemaRequest
 					"vip": schema.StringAttribute{
 						Optional:    true,
 						Description: "The virtual IP address of the VPN Router. This is only required when `plan` is not `standard`",
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.RequiresReplaceIfConfigured(),
-						},
 					},
 					"ip_addresses": schema.ListAttribute{
 						ElementType: types.StringType,
@@ -143,9 +139,6 @@ func (d *vpnRouterResource) Schema(ctx context.Context, _ resource.SchemaRequest
 						Validators: []validator.List{
 							listvalidator.SizeAtLeast(2),
 							listvalidator.SizeAtMost(2),
-						},
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.RequiresReplaceIfConfigured(),
 						},
 					},
 					"vrid": schema.Int64Attribute{
@@ -162,9 +155,6 @@ func (d *vpnRouterResource) Schema(ctx context.Context, _ resource.SchemaRequest
 						Validators: []validator.List{
 							listvalidator.SizeAtMost(19),
 						},
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.RequiresReplaceIfConfigured(),
-						},
 					},
 				},
 			},
@@ -175,6 +165,9 @@ func (d *vpnRouterResource) Schema(ctx context.Context, _ resource.SchemaRequest
 			"public_netmask": schema.Int64Attribute{
 				Computed:    true,
 				Description: "The bit length of the subnet to assign to the public network interface",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"syslog_host": schema.StringAttribute{
 				Optional:    true,


### PR DESCRIPTION
… add UseStateForUnknown to fixed netmask

<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

vpn_routerの`public_network_interface`の設定で、更新可能なのに`RequiresReplaceIfConfigured`がついていた属性があったので、それらを削除。
また、`public_netmask`は更新不可となっているので`UseStateForUnknown`を付与。

テストは通過

```
=== RUN   TestAccSakuraVPNRouterDataSource_Basic
--- PASS: TestAccSakuraVPNRouterDataSource_Basic (408.93s)
=== RUN   TestAccSakuraVPNRouter_basic
--- PASS: TestAccSakuraVPNRouter_basic (530.51s)
=== RUN   TestAccImportSakuraVPNRouter_basic
--- PASS: TestAccImportSakuraVPNRouter_basic (418.68s)
=== RUN   TestAccSakuraVPNRouter_Full
--- PASS: TestAccSakuraVPNRouter_Full (927.51s)
=== RUN   TestAccSakuraVPNRouter_WOFull
--- PASS: TestAccSakuraVPNRouter_WOFull (686.60s)
=== RUN   TestAccSakuraVPNRouter_Issue306
--- PASS: TestAccSakuraVPNRouter_Issue306 (665.11s)
PASS
ok  	github.com/sacloud/terraform-provider-sakura/internal/service/vpn_router	3638.104s
```

### ドキュメントの変更は必要ですか？

無し