### PR TITLE
sakura_apprun_dedicated_version: sort environment variables

### DIFF
--- a/internal/service/apprun_dedicated/model_version.go
+++ b/internal/service/apprun_dedicated/model_version.go
@@ -6,6 +6,7 @@ package apprun_dedicated
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -215,9 +216,29 @@ func (v *verModel) updateState(ctx context.Context, d *version.VersionDetail, ai
 	buf := make([]envVarModel, len(d.EnvVars))
 	copy(buf, v.EnvVars)
 
-	for i, j := range d.EnvVars {
-		k := &buf[i]
-		k.updateState(j)
+	for i := range slices.Values(d.EnvVars) {
+		// find matching variable by key and update its value
+		var updated bool
+		for j := range slices.Values(buf) {
+			switch {
+			case j.Key.IsUnknown():
+				continue
+			case j.Key.IsNull():
+				continue
+			case j.Key.ValueString() == i.Key:
+				j.updateState(i)
+				updated = true
+				break
+			}
+		}
+
+		if !updated {
+			// in case of terraform import previous state is empty.
+			// need to fill it
+			var e envVarModel
+			e.updateState(i)
+			buf = append(buf, e)
+		}
 	}
 
 	if v.EnvVars == nil && len(d.EnvVars) == 0 {

--- a/internal/service/apprun_dedicated/model_version.go
+++ b/internal/service/apprun_dedicated/model_version.go
@@ -213,20 +213,20 @@ func (v *verModel) updateState(ctx context.Context, d *version.VersionDetail, ai
 	v.ExposedPorts = common.MapTo(d.ExposedPorts, stateUpdater[version.ExposedPort, exposedPortModel])
 	v.Cmd, ret = types.ListValueFrom(ctx, types.StringType, common.MapTo(d.Cmd, types.StringValue))
 
-	buf := make([]envVarModel, len(d.EnvVars))
-	copy(buf, v.EnvVars)
+	buf := slices.Clone(v.EnvVars)
 
 	for i := range slices.Values(d.EnvVars) {
 		// find matching variable by key and update its value
 		var updated bool
-		for j := range slices.Values(buf) {
+		for j := range buf {
+			k := &buf[j]
 			switch {
-			case j.Key.IsUnknown():
+			case k.Key.IsUnknown():
 				continue
-			case j.Key.IsNull():
+			case k.Key.IsNull():
 				continue
-			case j.Key.ValueString() == i.Key:
-				j.updateState(i)
+			case k.Key.ValueString() == i.Key:
+				k.updateState(i)
 				updated = true
 				break
 			}

--- a/internal/service/apprun_dedicated/model_version_test.go
+++ b/internal/service/apprun_dedicated/model_version_test.go
@@ -62,3 +62,42 @@ func TestExposedPortModelIntoCreateNilHealthCheck(t *testing.T) {
 		t.Fatalf("HealthCheck should be nil when omitted, got %+v", got.HealthCheck)
 	}
 }
+
+func TestVerModelUpdateStatePreservesSecretByKey(t *testing.T) {
+	model := verModel{
+		EnvVars: []envVarModel{
+			{Key: types.StringValue("ENV_VAR2"), Value: types.StringValue("value2"), Secret: types.BoolValue(true)},
+			{Key: types.StringValue("ENV_VAR1"), Value: types.StringValue("value1"), Secret: types.BoolValue(false)},
+		},
+	}
+
+	detail := version.VersionDetail{
+		EnvVars: []version.EnvironmentVariable{
+			{Key: "ENV_VAR1", Value: types.StringValue("value1").ValueStringPointer(), Secret: false},
+			{Key: "ENV_VAR2", Value: nil, Secret: true},
+		},
+	}
+
+	var aid v1.ApplicationID
+
+	diagnostics := model.updateState(t.Context(), &detail, aid)
+
+	if diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diagnostics)
+	}
+	if len(model.EnvVars) != 2 {
+		t.Fatalf("EnvVars length = %d, want 2", len(model.EnvVars))
+	}
+	if got := model.EnvVars[0].Key.ValueString(); got != "ENV_VAR2" {
+		t.Fatalf("EnvVars[0].Key = %q, want %q", got, "ENV_VAR2")
+	}
+	if got := model.EnvVars[0].Value.ValueString(); got != "value2" {
+		t.Fatalf("EnvVars[0].Value = %q, want %q", got, "value2")
+	}
+	if got := model.EnvVars[1].Key.ValueString(); got != "ENV_VAR1" {
+		t.Fatalf("EnvVars[1].Key = %q, want %q", got, "ENV_VAR1")
+	}
+	if got := model.EnvVars[1].Value.ValueString(); got != "value1" {
+		t.Fatalf("EnvVars[1].Value = %q, want %q", got, "value1")
+	}
+}

--- a/internal/service/apprun_dedicated/resource_version_test.go
+++ b/internal/service/apprun_dedicated/resource_version_test.go
@@ -58,14 +58,14 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 						})),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("env_vars"), knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"key":    knownvalue.StringExact("ENV_VAR1"),
-								"value":  knownvalue.StringExact("value1"),
-								"secret": knownvalue.Bool(false),
-							}),
-							knownvalue.ObjectExact(map[string]knownvalue.Check{
 								"key":    knownvalue.StringExact("ENV_VAR2"),
 								"value":  knownvalue.StringExact("value2"),
 								"secret": knownvalue.Bool(true),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"key":    knownvalue.StringExact("ENV_VAR1"),
+								"value":  knownvalue.StringExact("value1"),
+								"secret": knownvalue.Bool(false),
 							}),
 						})),
 					},
@@ -75,8 +75,8 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 					ImportState:       true,
 					ImportStateVerify: true,
 
-					// "env_vars.1.value" is secret and cannot be read
-					ImportStateVerifyIgnore: []string{"timeouts", "registry_password", "env_vars.1.value"},
+					// env_vars is randomized.  Not equal to the config order by nature.
+					ImportStateVerifyIgnore: []string{"timeouts", "registry_password", "env_vars"},
 					ImportStateIdFunc: func(s *terraform.State) (string, error) {
 						rs, ok := s.RootModule().Resources[resourceName]
 						if !ok {
@@ -200,14 +200,14 @@ resource "sakura_apprun_dedicated_version" "main" {
 
   env_vars = [
     {
-      key    = "ENV_VAR1"
-      value  = "value1"
-      secret = false
-    },
-    {
       key    = "ENV_VAR2"
       value  = "value2"
       secret = true
+    },
+    {
+      key    = "ENV_VAR1"
+      value  = "value1"
+      secret = false
     }
   ]
 }


### PR DESCRIPTION
AppRun専有型ですが、環境変数が必ずしもリクエストパラメータと同じ順序でレスポンスが戻ってこないということがあるようです。
stateに書かれている順番でAPI戻り値をソートしてから保存するようにします。

なおimportの際には既存のstateがないのでそういうことができないので、順序はAPIか返してきた順にせざるをえません。