### PR TITLE
monitoring_suite: update alert_rule's query description for newline handling

### DIFF
--- a/docs/resources/monitoring_suite_alert_rule.md
+++ b/docs/resources/monitoring_suite_alert_rule.md
@@ -17,7 +17,7 @@ resource "sakura_monitoring_suite_alert_rule" "foobar" {
   name = "foobar"
   alert_project_id = "alert-project-resource-id" # e.g. sakura_monitoring_suite_alert_project.foobar.id
   metric_storage_id = "metric-storage-resource-id" # e.g. sakura_monitoring_suite_metric_storage.foobar.id 
-  query = "count_values"
+  query = "count_values" # If your query includes a newline at the end, e.g. use here document or file, call chomp function to remove a newline.
   enabled_warning = true
   enabled_critical = true
   threshold_warning = ">= 10"
@@ -35,7 +35,7 @@ resource "sakura_monitoring_suite_alert_rule" "foobar" {
 - `alert_project_id` (String) The resource ID of the Alert Project.
 - `metric_storage_id` (String) The resource ID of the Metric Storage.
 - `name` (String) The name of the Monitoring Suite Alert Rule.
-- `query` (String) The query of the Alert Rule.
+- `query` (String) The query of the Alert Rule. Don't include a newline at the end. If your query includes a newline at the end, e.g. use here document or file, call chomp function to remove a newline.
 
 ### Optional
 

--- a/examples/resources/sakura_monitoring_suite_alert_rule/resource.tf
+++ b/examples/resources/sakura_monitoring_suite_alert_rule/resource.tf
@@ -2,7 +2,7 @@ resource "sakura_monitoring_suite_alert_rule" "foobar" {
   name = "foobar"
   alert_project_id = "alert-project-resource-id" # e.g. sakura_monitoring_suite_alert_project.foobar.id
   metric_storage_id = "metric-storage-resource-id" # e.g. sakura_monitoring_suite_metric_storage.foobar.id 
-  query = "count_values"
+  query = "count_values" # If your query includes a newline at the end, e.g. use here document or file, call chomp function to remove a newline.
   enabled_warning = true
   enabled_critical = true
   threshold_warning = ">= 10"

--- a/internal/service/monitoring_suite/resource_alert_rule.go
+++ b/internal/service/monitoring_suite/resource_alert_rule.go
@@ -71,7 +71,7 @@ func (r *alertRuleResource) Schema(ctx context.Context, _ resource.SchemaRequest
 			},
 			"query": schema.StringAttribute{
 				Required:    true,
-				Description: "The query of the Alert Rule.",
+				Description: "The query of the Alert Rule. Don't include a newline at the end. If your query includes a newline at the end, e.g. use here document or file, call chomp function to remove a newline.",
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 4096),
 				},


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

monitoring_suite_alert_ruleのqueryは末尾に改行があるとAPIが削除して返してくる。リソース実装側で対処する方法もあるが、import等を考慮するとどこかで差分が出てしまうのは避けられず、terraformにはそのものずばりのchompが実装されているので、chompを利用してもらうことで複雑性を回避する。

### ドキュメントの変更は必要ですか？

更新。