### PR TITLE
nosql: Update database version to 4.1.11

### DIFF
--- a/internal/service/nosql/resource.go
+++ b/internal/service/nosql/resource.go
@@ -275,7 +275,7 @@ func (d *nosqlResource) Schema(ctx context.Context, _ resource.SchemaRequest, re
 							"version": schema.StringAttribute{
 								Optional:    true,
 								Computed:    true,
-								Default:     stringdefault.StaticString("4.1.10"),
+								Default:     stringdefault.StaticString("4.1.11"),
 								Description: "Version of database engine used by NoSQL appliance.",
 								Validators: []validator.String{
 									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\.\d+\.\d+$`), "invalid database version"),


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

nosqlで利用されるCassandraのバージョンが更新されたので追従する。

テストも全てパス。

### ドキュメントの変更は必要ですか？

デフォルト値の変更だけなので無し
