### PR TITLE
sakura_apprun_dedicated_version: need escape UUIDs

### DIFF
--- a/internal/service/apprun_dedicated/model_version.go
+++ b/internal/service/apprun_dedicated/model_version.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v1 "github.com/sacloud/apprun-dedicated-api-go/apis/v1"
@@ -194,7 +195,7 @@ func (p *exposedPortModel) updateState(d version.ExposedPort) {
 }
 
 func (v *verModel) updateState(ctx context.Context, d *version.VersionDetail, aid appID) (ret diag.Diagnostics) {
-	v.ID = types.StringValue(fmt.Sprintf("%s/%d", aid, d.Version))
+	v.ID = types.StringValue(fmt.Sprintf("%s/%d", uuid.UUID(aid).String(), d.Version))
 	v.Version = types.Int32Value(common.ToInt32(d.Version))
 	v.ApplicationID = uuid2StringValue(aid)
 	v.CPU = types.Int64Value(d.CPU)

--- a/internal/service/apprun_dedicated/model_version_test.go
+++ b/internal/service/apprun_dedicated/model_version_test.go
@@ -6,6 +6,7 @@ package apprun_dedicated
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v1 "github.com/sacloud/apprun-dedicated-api-go/apis/v1"
 	"github.com/sacloud/apprun-dedicated-api-go/apis/version"
@@ -99,5 +100,22 @@ func TestVerModelUpdateStatePreservesSecretByKey(t *testing.T) {
 	}
 	if got := model.EnvVars[1].Value.ValueString(); got != "value1" {
 		t.Fatalf("EnvVars[1].Value = %q, want %q", got, "value1")
+	}
+}
+
+func TestVerModelUpdateStateEscapesUUIDInID(t *testing.T) {
+	model := verModel{}
+
+	aid := v1.ApplicationID(uuid.MustParse("12345678-1234-1234-1234-123456789abc"))
+	detail := version.VersionDetail{Version: 42}
+
+	diag := model.updateState(t.Context(), &detail, aid)
+	if diag.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diag)
+	}
+
+	expected := "12345678-1234-1234-1234-123456789abc/42"
+	if actual := model.ID.ValueString(); actual != expected {
+		t.Fatalf("ID = %q, want %q", actual, expected)
 	}
 }


### PR DESCRIPTION
UUIDの実態は`[16]byte`なので`%s`に与えてもエラーにならず、気づくことなく壊れたIDが発生していました。

目視で確認したところでは他のIDでは同様の壊れ方は指定なさそうでした