### PR TITLE
sakura_apprun_dedicated_version: support write-only environment variables

### DIFF
--- a/docs/resources/apprun_dedicated_version.md
+++ b/docs/resources/apprun_dedicated_version.md
@@ -30,6 +30,20 @@ resource "sakura_apprun_dedicated_version" "main" {
   cmd            = ["/bin/sh"]
   scaling_mode   = "manual"
   fixed_scale    = 1
+
+  env_vars = [
+    {
+      key    = "LOG_LEVEL"
+      value  = "info"
+      secret = false
+    },
+    {
+      key              = "API_TOKEN"
+      value_wo         = "s3cr3t" # write-only: never stored in the state
+      value_wo_version = 1        # bump this to create a new version with a new value_wo
+      secret           = true
+    },
+  ]
 }
 ```
 
@@ -78,7 +92,9 @@ Required:
 
 Optional:
 
-- `value` (String) The value.  Omitting this field and set `secret` to true retains old secret value
+- `value` (String) The value.  Consider `value_wo` for secrets to keep them out of the state.  Omitting both this field and `value_wo` while `secret` is true retains old secret value
+- `value_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The value, write-only.  Unlike `value` this never lands in the state, whatever `secret` is (`secret` only controls whether the API conceals the value).  Must be set together with `value_wo_version`
+- `value_wo_version` (Number) The version of the `value_wo` field.  This value must be greater than 0 when set.  Terraform cannot detect changes of write-only values, so increment this to create a new application version with the new `value_wo`.  Note that `terraform import` cannot restore this field; the first plan after importing replaces the version unless `value_wo` and `value_wo_version` are left out of the configuration
 
 
 <a id="nestedatt--exposed_ports"></a>

--- a/docs/resources/apprun_dedicated_version.md
+++ b/docs/resources/apprun_dedicated_version.md
@@ -33,15 +33,16 @@ resource "sakura_apprun_dedicated_version" "main" {
 
   env_vars = [
     {
-      key    = "LOG_LEVEL"
-      value  = "info"
-      secret = false
+      key   = "LOG_LEVEL"
+      value = "info"
     },
+  ]
+
+  secret_vars = [
     {
       key              = "API_TOKEN"
       value_wo         = "s3cr3t" # write-only: never stored in the state
       value_wo_version = 1        # bump this to create a new version with a new value_wo
-      secret           = true
     },
   ]
 }
@@ -63,7 +64,7 @@ resource "sakura_apprun_dedicated_version" "main" {
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
 - `cmd` (List of String) application command line i.e. the command and arguments
-- `env_vars` (Attributes List) Environment variables (see [below for nested schema](#nestedatt--env_vars))
+- `env_vars` (Attributes List) Environment variables.  Use `secret_vars` for secrets (see [below for nested schema](#nestedatt--env_vars))
 - `exposed_ports` (Attributes List) Ports that the application exposes (see [below for nested schema](#nestedatt--exposed_ports))
 - `fixed_scale` (Number) Number of nodes when scaling mode is `manual`
 - `max_scale` (Number) Maximum number of nodes when scaling mode is `autoscale`
@@ -73,6 +74,7 @@ resource "sakura_apprun_dedicated_version" "main" {
 - `registry_username` (String) Login user name for the container registry
 - `scale_in_threshold` (Number) When to scale in when scaling mode is `autoscale`
 - `scale_out_threshold` (Number) When to scale out when scaling mode is `autoscale`
+- `secret_vars` (Attributes List) Secret environment variables.  Unlike `env_vars`, values are write-only and never land in the state.  `terraform import` puts every secret here; declare each as `{ key = "..." }` alone to adopt the imported version as is, and set `value_wo` only when a new version with a new value is wanted (see [below for nested schema](#nestedatt--secret_vars))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
@@ -88,13 +90,11 @@ resource "sakura_apprun_dedicated_version" "main" {
 Required:
 
 - `key` (String) Environment variable name
-- `secret` (Boolean) Whether the value is sensitive
 
 Optional:
 
-- `value` (String) The value.  Consider `value_wo` for secrets to keep them out of the state.  Omitting both this field and `value_wo` while `secret` is true retains old secret value
-- `value_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The value, write-only.  Unlike `value` this never lands in the state, whatever `secret` is (`secret` only controls whether the API conceals the value).  Must be set together with `value_wo_version`
-- `value_wo_version` (Number) The version of the `value_wo` field.  This value must be greater than 0 when set.  Terraform cannot detect changes of write-only values, so increment this to create a new application version with the new `value_wo`.  Note that `terraform import` cannot restore this field; the first plan after importing replaces the version unless `value_wo` and `value_wo_version` are left out of the configuration
+- `secret` (Boolean, Deprecated) Whether the value is sensitive
+- `value` (String) The value.  Use `secret_vars` for secrets.  Omitting this field with the deprecated `secret = true` retains the previous version's secret value
 
 
 <a id="nestedatt--exposed_ports"></a>
@@ -120,6 +120,19 @@ Required:
 - `path` (String) Health check endpoint
 - `timeout_seconds` (Number) Time out in seconds until the health check fails
 
+
+
+<a id="nestedatt--secret_vars"></a>
+### Nested Schema for `secret_vars`
+
+Required:
+
+- `key` (String) Environment variable name
+
+Optional:
+
+- `value_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The value, write-only.  Omitting this field retains the previous version's secret value.  Must be set together with `value_wo_version`
+- `value_wo_version` (Number) The version of the `value_wo` field.  This value must be greater than 0 when set.  Terraform cannot detect changes of write-only values, so increment this to create a new application version with the new `value_wo`.  Note that `terraform import` cannot restore this field
 
 
 <a id="nestedatt--timeouts"></a>

--- a/examples/resources/sakura_apprun_dedicated_version/resource.tf
+++ b/examples/resources/sakura_apprun_dedicated_version/resource.tf
@@ -15,4 +15,18 @@ resource "sakura_apprun_dedicated_version" "main" {
   cmd            = ["/bin/sh"]
   scaling_mode   = "manual"
   fixed_scale    = 1
+
+  env_vars = [
+    {
+      key    = "LOG_LEVEL"
+      value  = "info"
+      secret = false
+    },
+    {
+      key              = "API_TOKEN"
+      value_wo         = "s3cr3t" # write-only: never stored in the state
+      value_wo_version = 1        # bump this to create a new version with a new value_wo
+      secret           = true
+    },
+  ]
 }

--- a/examples/resources/sakura_apprun_dedicated_version/resource.tf
+++ b/examples/resources/sakura_apprun_dedicated_version/resource.tf
@@ -18,15 +18,16 @@ resource "sakura_apprun_dedicated_version" "main" {
 
   env_vars = [
     {
-      key    = "LOG_LEVEL"
-      value  = "info"
-      secret = false
+      key   = "LOG_LEVEL"
+      value = "info"
     },
+  ]
+
+  secret_vars = [
     {
       key              = "API_TOKEN"
       value_wo         = "s3cr3t" # write-only: never stored in the state
       value_wo_version = 1        # bump this to create a new version with a new value_wo
-      secret           = true
     },
   ]
 }

--- a/internal/service/apprun_dedicated/data_source_version.go
+++ b/internal/service/apprun_dedicated/data_source_version.go
@@ -19,7 +19,10 @@ import (
 )
 
 type verDataSource struct{ dataSourceClient }
-type verDataSourceModel struct{ verModel }
+type verDataSourceModel struct {
+	verModel
+	EnvVars []envVarModel `tfsdk:"env_vars"`
+}
 
 var (
 	_ datasource.DataSource              = &verDataSource{}

--- a/internal/service/apprun_dedicated/data_source_version.go
+++ b/internal/service/apprun_dedicated/data_source_version.go
@@ -19,10 +19,7 @@ import (
 )
 
 type verDataSource struct{ dataSourceClient }
-type verDataSourceModel struct {
-	verModel
-	EnvVars []envVarModel `tfsdk:"env_vars"`
-}
+type verDataSourceModel struct{ verModel }
 
 var (
 	_ datasource.DataSource              = &verDataSource{}

--- a/internal/service/apprun_dedicated/model_version.go
+++ b/internal/service/apprun_dedicated/model_version.go
@@ -28,6 +28,16 @@ type envVarModel struct {
 	Secret types.Bool   `tfsdk:"secret"`
 }
 
+// Resource-only variant of envVarModel.  value_wo is a write-only attribute,
+// which a data source cannot have.  Hence the separation.
+type envVarResourceModel struct {
+	Key            types.String `tfsdk:"key"`
+	Value          types.String `tfsdk:"value"`
+	ValueWO        types.String `tfsdk:"value_wo"`
+	ValueWOVersion types.Int32  `tfsdk:"value_wo_version"`
+	Secret         types.Bool   `tfsdk:"secret"`
+}
+
 type exposedPortModel struct {
 	TargetPort       types.Int32       `tfsdk:"target_port"`
 	LoadBalancerPort types.Int32       `tfsdk:"lb_port"`
@@ -54,7 +64,6 @@ type verModel struct {
 	ActiveNodeCount   types.Int64        `tfsdk:"active_node_count"`
 	CreatedAt         types.String       `tfsdk:"created_at"`
 	ExposedPorts      []exposedPortModel `tfsdk:"exposed_ports"`
-	EnvVars           []envVarModel      `tfsdk:"env_vars"`
 }
 
 var healthCheckAttrs = attrTypes{
@@ -97,7 +106,6 @@ var versionAttrs = attrTypes{
 	"active_node_count":        types.Int64Type,
 	"created_at":               types.StringType,
 	"exposed_ports":            types.ListType{ElemType: types.ObjectType{AttrTypes: exposedPortAttrs}},
-	"env_vars":                 types.ListType{ElemType: types.ObjectType{AttrTypes: envVarAttrs}},
 }
 
 func (healthCheckModel) AttributeTypes() attrTypes { return healthCheckAttrs }
@@ -118,7 +126,7 @@ func (h healthCheckModel) intoCreate() (ret v1.HealthCheck) {
 	return
 }
 
-func (e envVarModel) intoCreate() (ret version.EnvironmentVariable) {
+func (e envVarResourceModel) intoCreate() (ret version.EnvironmentVariable) {
 	ret.Key = e.Key.ValueString()
 	ret.Value = e.Value.ValueStringPointer()
 	ret.Secret = e.Secret.ValueBool()
@@ -156,12 +164,23 @@ func (h *healthCheckModel) updateState(d *v1.HealthCheck) {
 
 func (e *envVarModel) updateState(d version.EnvironmentVariable) {
 	e.Key = types.StringValue(d.Key)
+	e.Value = types.StringPointerValue(d.Value) // null when concealed
+	e.Secret = types.BoolValue(d.Secret)
+}
+
+func (e *envVarResourceModel) updateState(d version.EnvironmentVariable) {
+	e.Key = types.StringValue(d.Key)
 	e.Secret = types.BoolValue(d.Secret)
 
-	if d.Secret == true && d.Value == nil {
+	switch {
+	case !e.ValueWOVersion.IsNull():
+		// The value was given via value_wo, which is write-only.
+		// It must not land in the state even when the API tells us the value.
+		e.Value = types.StringNull()
+	case d.Secret && d.Value == nil:
 		// This means "value is concealed".
 		// However we already know the value from the state, so we keep it as is instead of setting to null.
-	} else {
+	default:
 		e.Value = types.StringPointerValue(d.Value)
 	}
 }
@@ -213,6 +232,19 @@ func (v *verModel) updateState(ctx context.Context, d *version.VersionDetail, ai
 	v.ExposedPorts = common.MapTo(d.ExposedPorts, stateUpdater[version.ExposedPort, exposedPortModel])
 	v.Cmd, ret = types.ListValueFrom(ctx, types.StringType, common.MapTo(d.Cmd, types.StringValue))
 
+	return ret
+}
+
+func (v *verDataSourceModel) updateState(ctx context.Context, d *version.VersionDetail, aid appID) (ret diag.Diagnostics) {
+	ret = v.verModel.updateState(ctx, d, aid)
+	v.EnvVars = common.MapTo(d.EnvVars, stateUpdater[version.EnvironmentVariable, envVarModel])
+
+	return ret
+}
+
+func (v *verResourceModel) updateState(ctx context.Context, d *version.VersionDetail, aid appID) (ret diag.Diagnostics) {
+	ret = v.verModel.updateState(ctx, d, aid)
+
 	buf := slices.Clone(v.EnvVars)
 
 	for i := range slices.Values(d.EnvVars) {
@@ -235,7 +267,7 @@ func (v *verModel) updateState(ctx context.Context, d *version.VersionDetail, ai
 		if !updated {
 			// in case of terraform import previous state is empty.
 			// need to fill it
-			var e envVarModel
+			var e envVarResourceModel
 			e.updateState(i)
 			buf = append(buf, e)
 		}

--- a/internal/service/apprun_dedicated/model_version.go
+++ b/internal/service/apprun_dedicated/model_version.go
@@ -28,14 +28,10 @@ type envVarModel struct {
 	Secret types.Bool   `tfsdk:"secret"`
 }
 
-// Resource-only variant of envVarModel.  value_wo is a write-only attribute,
-// which a data source cannot have.  Hence the separation.
-type envVarResourceModel struct {
+type secretVarModel struct {
 	Key            types.String `tfsdk:"key"`
-	Value          types.String `tfsdk:"value"`
 	ValueWO        types.String `tfsdk:"value_wo"`
 	ValueWOVersion types.Int32  `tfsdk:"value_wo_version"`
-	Secret         types.Bool   `tfsdk:"secret"`
 }
 
 type exposedPortModel struct {
@@ -64,6 +60,7 @@ type verModel struct {
 	ActiveNodeCount   types.Int64        `tfsdk:"active_node_count"`
 	CreatedAt         types.String       `tfsdk:"created_at"`
 	ExposedPorts      []exposedPortModel `tfsdk:"exposed_ports"`
+	EnvVars           []envVarModel      `tfsdk:"env_vars"`
 }
 
 var healthCheckAttrs = attrTypes{
@@ -76,6 +73,12 @@ var envVarAttrs = attrTypes{
 	"key":    types.StringType,
 	"value":  types.StringType,
 	"secret": types.BoolType,
+}
+
+var secretVarAttrs = attrTypes{
+	"key":              types.StringType,
+	"value_wo":         types.StringType,
+	"value_wo_version": types.Int32Type,
 }
 
 var exposedPortAttrs = attrTypes{
@@ -106,10 +109,13 @@ var versionAttrs = attrTypes{
 	"active_node_count":        types.Int64Type,
 	"created_at":               types.StringType,
 	"exposed_ports":            types.ListType{ElemType: types.ObjectType{AttrTypes: exposedPortAttrs}},
+	"env_vars":                 types.ListType{ElemType: types.ObjectType{AttrTypes: envVarAttrs}},
+	"secret_vars":              types.ListType{ElemType: types.ObjectType{AttrTypes: secretVarAttrs}},
 }
 
 func (healthCheckModel) AttributeTypes() attrTypes { return healthCheckAttrs }
 func (envVarModel) AttributeTypes() attrTypes      { return envVarAttrs }
+func (secretVarModel) AttributeTypes() attrTypes   { return secretVarAttrs }
 func (exposedPortModel) AttributeTypes() attrTypes { return exposedPortAttrs }
 func (verModel) AttributeTypes() attrTypes         { return versionAttrs }
 func (v *verModel) appId() (appID, error)          { return intoUUID[appID](v.ApplicationID) }
@@ -126,10 +132,18 @@ func (h healthCheckModel) intoCreate() (ret v1.HealthCheck) {
 	return
 }
 
-func (e envVarResourceModel) intoCreate() (ret version.EnvironmentVariable) {
+func (e envVarModel) intoCreate() (ret version.EnvironmentVariable) {
 	ret.Key = e.Key.ValueString()
 	ret.Value = e.Value.ValueStringPointer()
 	ret.Secret = e.Secret.ValueBool()
+
+	return
+}
+
+func (s secretVarModel) intoCreate(value *string) (ret version.EnvironmentVariable) {
+	ret.Key = s.Key.ValueString()
+	ret.Value = value
+	ret.Secret = true
 
 	return
 }
@@ -164,23 +178,12 @@ func (h *healthCheckModel) updateState(d *v1.HealthCheck) {
 
 func (e *envVarModel) updateState(d version.EnvironmentVariable) {
 	e.Key = types.StringValue(d.Key)
-	e.Value = types.StringPointerValue(d.Value) // null when concealed
-	e.Secret = types.BoolValue(d.Secret)
-}
-
-func (e *envVarResourceModel) updateState(d version.EnvironmentVariable) {
-	e.Key = types.StringValue(d.Key)
 	e.Secret = types.BoolValue(d.Secret)
 
-	switch {
-	case !e.ValueWOVersion.IsNull():
-		// The value was given via value_wo, which is write-only.
-		// It must not land in the state even when the API tells us the value.
-		e.Value = types.StringNull()
-	case d.Secret && d.Value == nil:
+	if d.Secret == true && d.Value == nil {
 		// This means "value is concealed".
 		// However we already know the value from the state, so we keep it as is instead of setting to null.
-	default:
+	} else {
 		e.Value = types.StringPointerValue(d.Value)
 	}
 }
@@ -232,19 +235,6 @@ func (v *verModel) updateState(ctx context.Context, d *version.VersionDetail, ai
 	v.ExposedPorts = common.MapTo(d.ExposedPorts, stateUpdater[version.ExposedPort, exposedPortModel])
 	v.Cmd, ret = types.ListValueFrom(ctx, types.StringType, common.MapTo(d.Cmd, types.StringValue))
 
-	return ret
-}
-
-func (v *verDataSourceModel) updateState(ctx context.Context, d *version.VersionDetail, aid appID) (ret diag.Diagnostics) {
-	ret = v.verModel.updateState(ctx, d, aid)
-	v.EnvVars = common.MapTo(d.EnvVars, stateUpdater[version.EnvironmentVariable, envVarModel])
-
-	return ret
-}
-
-func (v *verResourceModel) updateState(ctx context.Context, d *version.VersionDetail, aid appID) (ret diag.Diagnostics) {
-	ret = v.verModel.updateState(ctx, d, aid)
-
 	buf := slices.Clone(v.EnvVars)
 
 	for i := range slices.Values(d.EnvVars) {
@@ -267,7 +257,7 @@ func (v *verResourceModel) updateState(ctx context.Context, d *version.VersionDe
 		if !updated {
 			// in case of terraform import previous state is empty.
 			// need to fill it
-			var e envVarResourceModel
+			var e envVarModel
 			e.updateState(i)
 			buf = append(buf, e)
 		}
@@ -280,4 +270,39 @@ func (v *verResourceModel) updateState(ctx context.Context, d *version.VersionDe
 	}
 
 	return ret
+}
+
+func (v *verResourceModel) hasEnvVar(key string) bool {
+	return slices.ContainsFunc(v.EnvVars, func(e envVarModel) bool { return e.Key.ValueString() == key })
+}
+
+func (v *verResourceModel) hasSecretVar(key string) bool {
+	return slices.ContainsFunc(v.SecretVars, func(s secretVarModel) bool { return s.Key.ValueString() == key })
+}
+
+// secrets go to secret_vars, unless env_vars already has them (deprecated secret = true)
+func (v *verResourceModel) updateState(ctx context.Context, d *version.VersionDetail, aid appID) (ret diag.Diagnostics) {
+	rest := *d
+	rest.EnvVars = nil
+	buf := slices.Clone(v.SecretVars)
+
+	for i := range slices.Values(d.EnvVars) {
+		switch {
+		case v.hasSecretVar(i.Key):
+			// nothing to update
+		case i.Secret && i.Value == nil && !v.hasEnvVar(i.Key):
+			// terraform import; only the key is known
+			buf = append(buf, secretVarModel{Key: types.StringValue(i.Key)})
+		default:
+			rest.EnvVars = append(rest.EnvVars, i)
+		}
+	}
+
+	if v.SecretVars == nil && len(buf) == 0 {
+		// keep null, not empty list
+	} else {
+		v.SecretVars = buf
+	}
+
+	return v.verModel.updateState(ctx, &rest, aid)
 }

--- a/internal/service/apprun_dedicated/model_version_test.go
+++ b/internal/service/apprun_dedicated/model_version_test.go
@@ -4,11 +4,15 @@
 package apprun_dedicated
 
 import (
+	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	v1 "github.com/sacloud/sacloud-sdk-go/api/apprun-dedicated/apis/v1"
 	"github.com/sacloud/sacloud-sdk-go/api/apprun-dedicated/apis/version"
 )
@@ -65,9 +69,9 @@ func TestExposedPortModelIntoCreateNilHealthCheck(t *testing.T) {
 	}
 }
 
-func TestVerResourceModelUpdateStatePreservesSecretByKey(t *testing.T) {
-	model := verResourceModel{
-		EnvVars: []envVarResourceModel{
+func TestVerModelUpdateStatePreservesSecretByKey(t *testing.T) {
+	model := verModel{
+		EnvVars: []envVarModel{
 			{Key: types.StringValue("ENV_VAR2"), Value: types.StringValue("value2"), Secret: types.BoolValue(true)},
 			{Key: types.StringValue("ENV_VAR1"), Value: types.StringValue("value1"), Secret: types.BoolValue(false)},
 		},
@@ -104,174 +108,6 @@ func TestVerResourceModelUpdateStatePreservesSecretByKey(t *testing.T) {
 	}
 }
 
-// A value given via value_wo must never land in the state, whether or not the API conceals it.
-func TestVerResourceModelUpdateStateKeepsWriteOnlyValueOutOfState(t *testing.T) {
-	model := verResourceModel{
-		EnvVars: []envVarResourceModel{
-			// Value is seeded with garbage on purpose: value_wo_version must win over whatever is there.
-			{Key: types.StringValue("SECRET"), Value: types.StringValue("stale"), ValueWOVersion: types.Int32Value(1), Secret: types.BoolValue(true)},
-			{Key: types.StringValue("PLAIN"), ValueWOVersion: types.Int32Value(1), Secret: types.BoolValue(false)},
-		},
-	}
-
-	detail := version.VersionDetail{
-		EnvVars: []version.EnvironmentVariable{
-			{Key: "SECRET", Value: nil, Secret: true},
-			{Key: "PLAIN", Value: types.StringValue("plain").ValueStringPointer(), Secret: false},
-		},
-	}
-
-	var aid v1.ApplicationID
-
-	if diagnostics := model.updateState(t.Context(), &detail, aid); diagnostics.HasError() {
-		t.Fatalf("unexpected diagnostics: %v", diagnostics)
-	}
-	if len(model.EnvVars) != 2 {
-		t.Fatalf("EnvVars length = %d, want 2", len(model.EnvVars))
-	}
-	for _, e := range model.EnvVars {
-		key := e.Key.ValueString()
-
-		if !e.Value.IsNull() {
-			t.Fatalf("EnvVars[%s].Value = %q, want null", key, e.Value.ValueString())
-		}
-		if !e.ValueWO.IsNull() {
-			t.Fatalf("EnvVars[%s].ValueWO = %q, want null", key, e.ValueWO.ValueString())
-		}
-		if got := e.ValueWOVersion.ValueInt32(); got != 1 {
-			t.Fatalf("EnvVars[%s].ValueWOVersion = %d, want 1", key, got)
-		}
-	}
-}
-
-// terraform import starts from an empty state: every env var comes from the API as is, with nothing write-only.
-func TestVerResourceModelUpdateStateFillsEnvVarsOnImport(t *testing.T) {
-	var model verResourceModel
-
-	detail := version.VersionDetail{
-		EnvVars: []version.EnvironmentVariable{
-			{Key: "SECRET", Value: nil, Secret: true},
-			{Key: "PLAIN", Value: types.StringValue("plain").ValueStringPointer(), Secret: false},
-		},
-	}
-
-	var aid v1.ApplicationID
-
-	if diagnostics := model.updateState(t.Context(), &detail, aid); diagnostics.HasError() {
-		t.Fatalf("unexpected diagnostics: %v", diagnostics)
-	}
-	if len(model.EnvVars) != 2 {
-		t.Fatalf("EnvVars length = %d, want 2", len(model.EnvVars))
-	}
-	for _, e := range model.EnvVars {
-		key := e.Key.ValueString()
-
-		if !e.ValueWO.IsNull() || !e.ValueWOVersion.IsNull() {
-			t.Fatalf("EnvVars[%s] must not have write-only fields after import, got value_wo=%v value_wo_version=%v", key, e.ValueWO, e.ValueWOVersion)
-		}
-	}
-	if !model.EnvVars[0].Value.IsNull() {
-		t.Fatalf("EnvVars[0].Value = %q, want null", model.EnvVars[0].Value.ValueString())
-	}
-	if got := model.EnvVars[1].Value.ValueString(); got != "plain" {
-		t.Fatalf("EnvVars[1].Value = %q, want %q", got, "plain")
-	}
-}
-
-// Write-only values are absent from the plan; intoCreate has to pick them up from the config.
-func TestVerResourceModelIntoCreateTakesWriteOnlyValueFromConfig(t *testing.T) {
-	plan := verResourceModel{
-		EnvVars: []envVarResourceModel{
-			{Key: types.StringValue("SECRET"), ValueWOVersion: types.Int32Value(1), Secret: types.BoolValue(true)},
-			{Key: types.StringValue("PLAIN"), Value: types.StringValue("plain"), Secret: types.BoolValue(false)},
-		},
-	}
-	config := verResourceModel{
-		EnvVars: []envVarResourceModel{
-			{Key: types.StringValue("SECRET"), ValueWO: types.StringValue("s3cr3t"), ValueWOVersion: types.Int32Value(1), Secret: types.BoolValue(true)},
-			{Key: types.StringValue("PLAIN"), Value: types.StringValue("plain"), Secret: types.BoolValue(false)},
-		},
-	}
-
-	params, diagnostics := plan.intoCreate(&config)
-
-	if diagnostics.HasError() {
-		t.Fatalf("unexpected diagnostics: %v", diagnostics)
-	}
-	if len(params.EnvVars) != 2 {
-		t.Fatalf("EnvVars length = %d, want 2", len(params.EnvVars))
-	}
-	if got := params.EnvVars[0]; got.Key != "SECRET" || got.Value == nil || *got.Value != "s3cr3t" || !got.Secret {
-		t.Fatalf("EnvVars[0] = {Key: %q, Value: %v, Secret: %t}, want {Key: \"SECRET\", Value: \"s3cr3t\", Secret: true}", got.Key, got.Value, got.Secret)
-	}
-	if got := params.EnvVars[1]; got.Key != "PLAIN" || got.Value == nil || *got.Value != "plain" || got.Secret {
-		t.Fatalf("EnvVars[1] = {Key: %q, Value: %v, Secret: %t}, want {Key: \"PLAIN\", Value: \"plain\", Secret: false}", got.Key, got.Value, got.Secret)
-	}
-}
-
-// A plan/config mismatch must surface as an error, never as a silently dropped secret.
-func TestVerResourceModelIntoCreateRejectsInconsistentEnvVars(t *testing.T) {
-	plan := verResourceModel{
-		EnvVars: []envVarResourceModel{
-			{Key: types.StringValue("SECRET"), ValueWOVersion: types.Int32Value(1), Secret: types.BoolValue(true)},
-		},
-	}
-
-	for name, config := range map[string]verResourceModel{
-		"fewer elements": {},
-		"different key": {
-			EnvVars: []envVarResourceModel{
-				{Key: types.StringValue("OTHER"), ValueWO: types.StringValue("s3cr3t"), ValueWOVersion: types.Int32Value(1), Secret: types.BoolValue(true)},
-			},
-		},
-	} {
-		if _, diagnostics := plan.intoCreate(&config); !diagnostics.HasError() {
-			t.Fatalf("%s: expected an error diagnostic, got none", name)
-		}
-	}
-}
-
-// The data source has no prior state to preserve secret values from; the API conceals them.
-func TestVerDataSourceModelUpdateStateConcealsSecret(t *testing.T) {
-	var model verDataSourceModel
-
-	detail := version.VersionDetail{
-		EnvVars: []version.EnvironmentVariable{
-			{Key: "SECRET", Value: nil, Secret: true},
-			{Key: "PLAIN", Value: types.StringValue("plain").ValueStringPointer(), Secret: false},
-		},
-	}
-
-	var aid v1.ApplicationID
-
-	if diagnostics := model.updateState(t.Context(), &detail, aid); diagnostics.HasError() {
-		t.Fatalf("unexpected diagnostics: %v", diagnostics)
-	}
-	if len(model.EnvVars) != 2 {
-		t.Fatalf("EnvVars length = %d, want 2", len(model.EnvVars))
-	}
-	if !model.EnvVars[0].Value.IsNull() {
-		t.Fatalf("EnvVars[0].Value = %q, want null", model.EnvVars[0].Value.ValueString())
-	}
-	if got := model.EnvVars[1].Value.ValueString(); got != "plain" {
-		t.Fatalf("EnvVars[1].Value = %q, want %q", got, "plain")
-	}
-}
-
-// Write-only attributes come with structural rules (no Computed, not under a Set, ...) that the framework enforces.
-func TestVerResourceSchemaValidateImplementation(t *testing.T) {
-	var res resource.SchemaResponse
-
-	NewVersionResource().Schema(t.Context(), resource.SchemaRequest{}, &res)
-
-	if res.Diagnostics.HasError() {
-		t.Fatalf("unexpected diagnostics: %v", res.Diagnostics)
-	}
-	if diagnostics := res.Schema.ValidateImplementation(t.Context()); diagnostics.HasError() {
-		t.Fatalf("invalid schema: %v", diagnostics)
-	}
-}
-
 func TestVerModelUpdateStateEscapesUUIDInID(t *testing.T) {
 	model := verModel{}
 
@@ -286,5 +122,209 @@ func TestVerModelUpdateStateEscapesUUIDInID(t *testing.T) {
 	expected := "12345678-1234-1234-1234-123456789abc/42"
 	if actual := model.ID.ValueString(); actual != expected {
 		t.Fatalf("ID = %q, want %q", actual, expected)
+	}
+}
+
+// import: secrets go to secret_vars, the rest to env_vars
+func TestVerResourceModelUpdateStateRoutesSecretsOnImport(t *testing.T) {
+	var model verResourceModel
+
+	detail := version.VersionDetail{
+		EnvVars: []version.EnvironmentVariable{
+			{Key: "SECRET", Value: nil, Secret: true},
+			{Key: "PLAIN", Value: types.StringValue("plain").ValueStringPointer(), Secret: false},
+		},
+	}
+
+	var aid v1.ApplicationID
+
+	if diagnostics := model.updateState(t.Context(), &detail, aid); diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diagnostics)
+	}
+	if len(model.SecretVars) != 1 || len(model.EnvVars) != 1 {
+		t.Fatalf("SecretVars length = %d, EnvVars length = %d, want 1 and 1", len(model.SecretVars), len(model.EnvVars))
+	}
+	if got := model.SecretVars[0]; got.Key.ValueString() != "SECRET" || !got.ValueWO.IsNull() || !got.ValueWOVersion.IsNull() {
+		t.Fatalf("SecretVars[0] = %+v, want {Key: \"SECRET\", ValueWO: null, ValueWOVersion: null}", got)
+	}
+	if got := model.EnvVars[0]; got.Key.ValueString() != "PLAIN" || got.Value.ValueString() != "plain" || got.Secret.ValueBool() {
+		t.Fatalf("EnvVars[0] = %+v, want {Key: \"PLAIN\", Value: \"plain\", Secret: false}", got)
+	}
+}
+
+// deprecated secret = true stays in env_vars
+func TestVerResourceModelUpdateStateKeepsSecretVarsAndLegacyApart(t *testing.T) {
+	model := verResourceModel{
+		verModel: verModel{
+			EnvVars: []envVarModel{
+				{Key: types.StringValue("LEGACY"), Value: types.StringValue("legacy"), Secret: types.BoolValue(true)},
+			},
+		},
+		SecretVars: []secretVarModel{
+			{Key: types.StringValue("NEW"), ValueWOVersion: types.Int32Value(1)},
+		},
+	}
+
+	detail := version.VersionDetail{
+		EnvVars: []version.EnvironmentVariable{
+			{Key: "NEW", Value: nil, Secret: true},
+			{Key: "LEGACY", Value: nil, Secret: true},
+		},
+	}
+
+	var aid v1.ApplicationID
+
+	if diagnostics := model.updateState(t.Context(), &detail, aid); diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diagnostics)
+	}
+	if len(model.SecretVars) != 1 || len(model.EnvVars) != 1 {
+		t.Fatalf("SecretVars length = %d, EnvVars length = %d, want 1 and 1", len(model.SecretVars), len(model.EnvVars))
+	}
+	if got := model.SecretVars[0]; got.Key.ValueString() != "NEW" || !got.ValueWO.IsNull() || got.ValueWOVersion.ValueInt32() != 1 {
+		t.Fatalf("SecretVars[0] = %+v, want {Key: \"NEW\", ValueWO: null, ValueWOVersion: 1}", got)
+	}
+	if got := model.EnvVars[0]; got.Key.ValueString() != "LEGACY" || got.Value.ValueString() != "legacy" || !got.Secret.ValueBool() {
+		t.Fatalf("EnvVars[0] = %+v, want {Key: \"LEGACY\", Value: \"legacy\", Secret: true}", got)
+	}
+}
+
+// write-only values come from the config, not the plan
+func TestVerResourceModelIntoCreateMergesSecretVars(t *testing.T) {
+	plan := verResourceModel{
+		verModel: verModel{
+			EnvVars: []envVarModel{
+				{Key: types.StringValue("PLAIN"), Value: types.StringValue("plain"), Secret: types.BoolValue(false)},
+			},
+		},
+		SecretVars: []secretVarModel{
+			{Key: types.StringValue("SECRET"), ValueWOVersion: types.Int32Value(1)},
+			{Key: types.StringValue("RETAINED")},
+		},
+	}
+	config := verResourceModel{
+		verModel: plan.verModel,
+		SecretVars: []secretVarModel{
+			{Key: types.StringValue("SECRET"), ValueWO: types.StringValue("s3cr3t"), ValueWOVersion: types.Int32Value(1)},
+			{Key: types.StringValue("RETAINED")},
+		},
+	}
+
+	params, diagnostics := plan.intoCreate(&config)
+
+	if diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diagnostics)
+	}
+	if len(params.EnvVars) != 3 {
+		t.Fatalf("EnvVars length = %d, want 3", len(params.EnvVars))
+	}
+	if got := params.EnvVars[0]; got.Key != "PLAIN" || got.Value == nil || *got.Value != "plain" || got.Secret {
+		t.Fatalf("EnvVars[0] = {Key: %q, Value: %v, Secret: %t}, want {Key: \"PLAIN\", Value: \"plain\", Secret: false}", got.Key, got.Value, got.Secret)
+	}
+	if got := params.EnvVars[1]; got.Key != "SECRET" || got.Value == nil || *got.Value != "s3cr3t" || !got.Secret {
+		t.Fatalf("EnvVars[1] = {Key: %q, Value: %v, Secret: %t}, want {Key: \"SECRET\", Value: \"s3cr3t\", Secret: true}", got.Key, got.Value, got.Secret)
+	}
+	if got := params.EnvVars[2]; got.Key != "RETAINED" || got.Value != nil || !got.Secret {
+		t.Fatalf("EnvVars[2] = {Key: %q, Value: %v, Secret: %t}, want {Key: \"RETAINED\", Value: nil, Secret: true}", got.Key, got.Value, got.Secret)
+	}
+}
+
+// plan/config mismatch is an error, not a silently dropped secret
+func TestVerResourceModelIntoCreateRejectsInconsistentSecretVars(t *testing.T) {
+	plan := verResourceModel{
+		SecretVars: []secretVarModel{
+			{Key: types.StringValue("SECRET"), ValueWOVersion: types.Int32Value(1)},
+		},
+	}
+
+	for name, config := range map[string]verResourceModel{
+		"fewer elements": {},
+		"different key": {
+			SecretVars: []secretVarModel{
+				{Key: types.StringValue("OTHER"), ValueWO: types.StringValue("s3cr3t"), ValueWOVersion: types.Int32Value(1)},
+			},
+		},
+	} {
+		if _, diagnostics := plan.intoCreate(&config); !diagnostics.HasError() {
+			t.Fatalf("%s: expected an error diagnostic, got none", name)
+		}
+	}
+}
+
+// write-only attributes have structural rules the framework checks only at runtime
+func TestVerResourceSchemaValidateImplementation(t *testing.T) {
+	var res resource.SchemaResponse
+
+	NewVersionResource().Schema(t.Context(), resource.SchemaRequest{}, &res)
+
+	if res.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", res.Diagnostics)
+	}
+	if diagnostics := res.Schema.ValidateImplementation(t.Context()); diagnostics.HasError() {
+		t.Fatalf("invalid schema: %v", diagnostics)
+	}
+}
+
+// no key in both lists, at most 50 in total; unknown values must not error
+func TestVerResourceValidateConfig(t *testing.T) {
+	ctx := t.Context()
+
+	var sch resource.SchemaResponse
+	NewVersionResource().Schema(ctx, resource.SchemaRequest{}, &sch)
+
+	envVarsType := sch.Schema.Attributes["env_vars"].GetType().TerraformType(ctx).(tftypes.List)
+	secretVarsType := sch.Schema.Attributes["secret_vars"].GetType().TerraformType(ctx).(tftypes.List)
+
+	envVar := func(key any) tftypes.Value {
+		return tftypes.NewValue(envVarsType.ElementType, map[string]tftypes.Value{
+			"key":    tftypes.NewValue(tftypes.String, key),
+			"value":  tftypes.NewValue(tftypes.String, "plain"),
+			"secret": tftypes.NewValue(tftypes.Bool, nil),
+		})
+	}
+	secretVar := func(key any) tftypes.Value {
+		return tftypes.NewValue(secretVarsType.ElementType, map[string]tftypes.Value{
+			"key":              tftypes.NewValue(tftypes.String, key),
+			"value_wo":         tftypes.NewValue(tftypes.String, "s3cr3t"),
+			"value_wo_version": tftypes.NewValue(tftypes.Number, big.NewFloat(1)),
+		})
+	}
+	many := func(n int, prefix string, elem func(key any) tftypes.Value) []tftypes.Value {
+		ret := make([]tftypes.Value, 0, n)
+		for i := range n {
+			ret = append(ret, elem(fmt.Sprintf("%s%d", prefix, i)))
+		}
+		return ret
+	}
+	configWith := func(envVars, secretVars any) tfsdk.Config {
+		attrs := make(map[string]tftypes.Value, len(sch.Schema.Attributes))
+		for name, a := range sch.Schema.Attributes {
+			attrs[name] = tftypes.NewValue(a.GetType().TerraformType(ctx), nil)
+		}
+		attrs["env_vars"] = tftypes.NewValue(envVarsType, envVars)
+		attrs["secret_vars"] = tftypes.NewValue(secretVarsType, secretVars)
+
+		return tfsdk.Config{Schema: sch.Schema, Raw: tftypes.NewValue(sch.Schema.Type().TerraformType(ctx), attrs)}
+	}
+
+	for name, c := range map[string]struct {
+		envVars, secretVars any
+		wantError           bool
+	}{
+		"distinct keys":    {[]tftypes.Value{envVar("PLAIN")}, []tftypes.Value{secretVar("SECRET")}, false},
+		"duplicate key":    {[]tftypes.Value{envVar("DUP")}, []tftypes.Value{secretVar("DUP")}, true},
+		"50 in total":      {many(25, "E", envVar), many(25, "S", secretVar), false},
+		"51 in total":      {many(26, "E", envVar), many(25, "S", secretVar), true},
+		"env_vars unknown": {tftypes.UnknownValue, []tftypes.Value{secretVar("DUP")}, false},
+		"secret_vars null": {[]tftypes.Value{envVar("DUP")}, nil, false},
+		"unknown element":  {[]tftypes.Value{envVar("DUP")}, []tftypes.Value{tftypes.NewValue(secretVarsType.ElementType, tftypes.UnknownValue)}, false},
+		"unknown key":      {[]tftypes.Value{envVar("DUP")}, []tftypes.Value{secretVar(tftypes.UnknownValue)}, false},
+	} {
+		var res resource.ValidateConfigResponse
+
+		NewVersionResource().(resource.ResourceWithValidateConfig).ValidateConfig(ctx, resource.ValidateConfigRequest{Config: configWith(c.envVars, c.secretVars)}, &res)
+
+		if res.Diagnostics.HasError() != c.wantError {
+			t.Fatalf("%s: HasError() = %t, want %t: %v", name, !c.wantError, c.wantError, res.Diagnostics)
+		}
 	}
 }

--- a/internal/service/apprun_dedicated/model_version_test.go
+++ b/internal/service/apprun_dedicated/model_version_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	v1 "github.com/sacloud/sacloud-sdk-go/api/apprun-dedicated/apis/v1"
 	"github.com/sacloud/sacloud-sdk-go/api/apprun-dedicated/apis/version"
@@ -64,9 +65,9 @@ func TestExposedPortModelIntoCreateNilHealthCheck(t *testing.T) {
 	}
 }
 
-func TestVerModelUpdateStatePreservesSecretByKey(t *testing.T) {
-	model := verModel{
-		EnvVars: []envVarModel{
+func TestVerResourceModelUpdateStatePreservesSecretByKey(t *testing.T) {
+	model := verResourceModel{
+		EnvVars: []envVarResourceModel{
 			{Key: types.StringValue("ENV_VAR2"), Value: types.StringValue("value2"), Secret: types.BoolValue(true)},
 			{Key: types.StringValue("ENV_VAR1"), Value: types.StringValue("value1"), Secret: types.BoolValue(false)},
 		},
@@ -100,6 +101,174 @@ func TestVerModelUpdateStatePreservesSecretByKey(t *testing.T) {
 	}
 	if got := model.EnvVars[1].Value.ValueString(); got != "value1" {
 		t.Fatalf("EnvVars[1].Value = %q, want %q", got, "value1")
+	}
+}
+
+// A value given via value_wo must never land in the state, whether or not the API conceals it.
+func TestVerResourceModelUpdateStateKeepsWriteOnlyValueOutOfState(t *testing.T) {
+	model := verResourceModel{
+		EnvVars: []envVarResourceModel{
+			// Value is seeded with garbage on purpose: value_wo_version must win over whatever is there.
+			{Key: types.StringValue("SECRET"), Value: types.StringValue("stale"), ValueWOVersion: types.Int32Value(1), Secret: types.BoolValue(true)},
+			{Key: types.StringValue("PLAIN"), ValueWOVersion: types.Int32Value(1), Secret: types.BoolValue(false)},
+		},
+	}
+
+	detail := version.VersionDetail{
+		EnvVars: []version.EnvironmentVariable{
+			{Key: "SECRET", Value: nil, Secret: true},
+			{Key: "PLAIN", Value: types.StringValue("plain").ValueStringPointer(), Secret: false},
+		},
+	}
+
+	var aid v1.ApplicationID
+
+	if diagnostics := model.updateState(t.Context(), &detail, aid); diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diagnostics)
+	}
+	if len(model.EnvVars) != 2 {
+		t.Fatalf("EnvVars length = %d, want 2", len(model.EnvVars))
+	}
+	for _, e := range model.EnvVars {
+		key := e.Key.ValueString()
+
+		if !e.Value.IsNull() {
+			t.Fatalf("EnvVars[%s].Value = %q, want null", key, e.Value.ValueString())
+		}
+		if !e.ValueWO.IsNull() {
+			t.Fatalf("EnvVars[%s].ValueWO = %q, want null", key, e.ValueWO.ValueString())
+		}
+		if got := e.ValueWOVersion.ValueInt32(); got != 1 {
+			t.Fatalf("EnvVars[%s].ValueWOVersion = %d, want 1", key, got)
+		}
+	}
+}
+
+// terraform import starts from an empty state: every env var comes from the API as is, with nothing write-only.
+func TestVerResourceModelUpdateStateFillsEnvVarsOnImport(t *testing.T) {
+	var model verResourceModel
+
+	detail := version.VersionDetail{
+		EnvVars: []version.EnvironmentVariable{
+			{Key: "SECRET", Value: nil, Secret: true},
+			{Key: "PLAIN", Value: types.StringValue("plain").ValueStringPointer(), Secret: false},
+		},
+	}
+
+	var aid v1.ApplicationID
+
+	if diagnostics := model.updateState(t.Context(), &detail, aid); diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diagnostics)
+	}
+	if len(model.EnvVars) != 2 {
+		t.Fatalf("EnvVars length = %d, want 2", len(model.EnvVars))
+	}
+	for _, e := range model.EnvVars {
+		key := e.Key.ValueString()
+
+		if !e.ValueWO.IsNull() || !e.ValueWOVersion.IsNull() {
+			t.Fatalf("EnvVars[%s] must not have write-only fields after import, got value_wo=%v value_wo_version=%v", key, e.ValueWO, e.ValueWOVersion)
+		}
+	}
+	if !model.EnvVars[0].Value.IsNull() {
+		t.Fatalf("EnvVars[0].Value = %q, want null", model.EnvVars[0].Value.ValueString())
+	}
+	if got := model.EnvVars[1].Value.ValueString(); got != "plain" {
+		t.Fatalf("EnvVars[1].Value = %q, want %q", got, "plain")
+	}
+}
+
+// Write-only values are absent from the plan; intoCreate has to pick them up from the config.
+func TestVerResourceModelIntoCreateTakesWriteOnlyValueFromConfig(t *testing.T) {
+	plan := verResourceModel{
+		EnvVars: []envVarResourceModel{
+			{Key: types.StringValue("SECRET"), ValueWOVersion: types.Int32Value(1), Secret: types.BoolValue(true)},
+			{Key: types.StringValue("PLAIN"), Value: types.StringValue("plain"), Secret: types.BoolValue(false)},
+		},
+	}
+	config := verResourceModel{
+		EnvVars: []envVarResourceModel{
+			{Key: types.StringValue("SECRET"), ValueWO: types.StringValue("s3cr3t"), ValueWOVersion: types.Int32Value(1), Secret: types.BoolValue(true)},
+			{Key: types.StringValue("PLAIN"), Value: types.StringValue("plain"), Secret: types.BoolValue(false)},
+		},
+	}
+
+	params, diagnostics := plan.intoCreate(&config)
+
+	if diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diagnostics)
+	}
+	if len(params.EnvVars) != 2 {
+		t.Fatalf("EnvVars length = %d, want 2", len(params.EnvVars))
+	}
+	if got := params.EnvVars[0]; got.Key != "SECRET" || got.Value == nil || *got.Value != "s3cr3t" || !got.Secret {
+		t.Fatalf("EnvVars[0] = {Key: %q, Value: %v, Secret: %t}, want {Key: \"SECRET\", Value: \"s3cr3t\", Secret: true}", got.Key, got.Value, got.Secret)
+	}
+	if got := params.EnvVars[1]; got.Key != "PLAIN" || got.Value == nil || *got.Value != "plain" || got.Secret {
+		t.Fatalf("EnvVars[1] = {Key: %q, Value: %v, Secret: %t}, want {Key: \"PLAIN\", Value: \"plain\", Secret: false}", got.Key, got.Value, got.Secret)
+	}
+}
+
+// A plan/config mismatch must surface as an error, never as a silently dropped secret.
+func TestVerResourceModelIntoCreateRejectsInconsistentEnvVars(t *testing.T) {
+	plan := verResourceModel{
+		EnvVars: []envVarResourceModel{
+			{Key: types.StringValue("SECRET"), ValueWOVersion: types.Int32Value(1), Secret: types.BoolValue(true)},
+		},
+	}
+
+	for name, config := range map[string]verResourceModel{
+		"fewer elements": {},
+		"different key": {
+			EnvVars: []envVarResourceModel{
+				{Key: types.StringValue("OTHER"), ValueWO: types.StringValue("s3cr3t"), ValueWOVersion: types.Int32Value(1), Secret: types.BoolValue(true)},
+			},
+		},
+	} {
+		if _, diagnostics := plan.intoCreate(&config); !diagnostics.HasError() {
+			t.Fatalf("%s: expected an error diagnostic, got none", name)
+		}
+	}
+}
+
+// The data source has no prior state to preserve secret values from; the API conceals them.
+func TestVerDataSourceModelUpdateStateConcealsSecret(t *testing.T) {
+	var model verDataSourceModel
+
+	detail := version.VersionDetail{
+		EnvVars: []version.EnvironmentVariable{
+			{Key: "SECRET", Value: nil, Secret: true},
+			{Key: "PLAIN", Value: types.StringValue("plain").ValueStringPointer(), Secret: false},
+		},
+	}
+
+	var aid v1.ApplicationID
+
+	if diagnostics := model.updateState(t.Context(), &detail, aid); diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diagnostics)
+	}
+	if len(model.EnvVars) != 2 {
+		t.Fatalf("EnvVars length = %d, want 2", len(model.EnvVars))
+	}
+	if !model.EnvVars[0].Value.IsNull() {
+		t.Fatalf("EnvVars[0].Value = %q, want null", model.EnvVars[0].Value.ValueString())
+	}
+	if got := model.EnvVars[1].Value.ValueString(); got != "plain" {
+		t.Fatalf("EnvVars[1].Value = %q, want %q", got, "plain")
+	}
+}
+
+// Write-only attributes come with structural rules (no Computed, not under a Set, ...) that the framework enforces.
+func TestVerResourceSchemaValidateImplementation(t *testing.T) {
+	var res resource.SchemaResponse
+
+	NewVersionResource().Schema(t.Context(), resource.SchemaRequest{}, &res)
+
+	if res.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", res.Diagnostics)
+	}
+	if diagnostics := res.Schema.ValidateImplementation(t.Context()); diagnostics.HasError() {
+		t.Fatalf("invalid schema: %v", diagnostics)
 	}
 }
 

--- a/internal/service/apprun_dedicated/resource_version.go
+++ b/internal/service/apprun_dedicated/resource_version.go
@@ -42,9 +42,10 @@ type verResource struct{ resourceClient }
 
 type verResourceModel struct {
 	verModel
-	RegistryPassword       types.String   `tfsdk:"registry_password"`
-	RegistryPasswordAction types.String   `tfsdk:"registry_password_action"`
-	Timeouts               timeouts.Value `tfsdk:"timeouts"`
+	EnvVars                []envVarResourceModel `tfsdk:"env_vars"`
+	RegistryPassword       types.String          `tfsdk:"registry_password"`
+	RegistryPasswordAction types.String          `tfsdk:"registry_password_action"`
+	Timeouts               timeouts.Value        `tfsdk:"timeouts"`
 }
 
 var (
@@ -248,9 +249,30 @@ func (r *verResource) Schema(ctx context.Context, _ resource.SchemaRequest, res 
 						},
 						"value": schema.StringAttribute{
 							Optional:      true,
-							Description:   "The value.  Omitting this field and set `secret` to true retains old secret value",
+							Description:   "The value.  Consider `value_wo` for secrets to keep them out of the state.  Omitting both this field and `value_wo` while `secret` is true retains old secret value",
 							Validators:    []validator.String{stringvalidator.LengthAtMost(4096)},
 							PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+						},
+						"value_wo": schema.StringAttribute{
+							WriteOnly:   true,
+							Optional:    true,
+							Description: "The value, write-only.  Unlike `value` this never lands in the state, whatever `secret` is (`secret` only controls whether the API conceals the value).  Must be set together with `value_wo_version`",
+							Validators: []validator.String{
+								stringvalidator.LengthAtMost(4096),
+								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("value")),
+								stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("value_wo_version")),
+							},
+							// No RequiresReplace here: a write-only value is null in both plan and state, so it could never fire.
+							// Replacement is driven by value_wo_version.
+						},
+						"value_wo_version": schema.Int32Attribute{
+							Optional:    true,
+							Description: "The version of the `value_wo` field.  This value must be greater than 0 when set.  Terraform cannot detect changes of write-only values, so increment this to create a new application version with the new `value_wo`.  Note that `terraform import` cannot restore this field; the first plan after importing replaces the version unless `value_wo` and `value_wo_version` are left out of the configuration",
+							Validators: []validator.Int32{
+								int32validator.AtLeast(1),
+								int32validator.AlsoRequires(path.MatchRelative().AtParent().AtName("value_wo")),
+							},
+							PlanModifiers: []planmodifier.Int32{int32planmodifier.RequiresReplace()},
 						},
 						"secret": schema.BoolAttribute{
 							Required:      true,
@@ -421,13 +443,40 @@ func (v *verResourceModel) intoCreate(transitional *verResourceModel) (ret ver.C
 		diag.Append(d...)
 		return dst
 	})
-	ret.EnvVars = common.MapTo(v.EnvVars, envVarModel.intoCreate)
+	envVars, d := v.envVarsIntoCreate(transitional)
+	ret.EnvVars = envVars
+	diag.Append(d...)
 
 	// API cannot omit RegistryPasswordAction, but can omit username and password...
 	ret.RegistryPasswordAction = v1.RegistryPasswordActionRemove
 
 	if !v.RegistryPasswordAction.IsNull() && !v.RegistryPasswordAction.IsUnknown() {
 		ret.RegistryPasswordAction = v1.RegistryPasswordAction(v.RegistryPasswordAction.ValueString())
+	}
+
+	return
+}
+
+// Write-only values never appear in the plan.  Take them from the config.
+// env_vars has no computed child attribute, so the plan is a copy of the config and the two lists are index-aligned.
+// Should that ever not hold, fail loudly rather than silently dropping a secret.
+func (v *verResourceModel) envVarsIntoCreate(config *verResourceModel) (ret []ver.EnvironmentVariable, diag diag.Diagnostics) {
+	if len(config.EnvVars) != len(v.EnvVars) {
+		diag.AddError("Create: Inconsistent Configuration", fmt.Sprintf("env_vars has %d elements in the plan but %d in the config", len(v.EnvVars), len(config.EnvVars)))
+		return
+	}
+
+	ret = common.MapTo(v.EnvVars, envVarResourceModel.intoCreate)
+
+	for i, e := range config.EnvVars {
+		if key := e.Key.ValueString(); key != ret[i].Key {
+			diag.AddError("Create: Inconsistent Configuration", fmt.Sprintf("env_vars[%d] is %q in the plan but %q in the config", i, ret[i].Key, key))
+			return
+		}
+
+		if !e.ValueWO.IsNull() {
+			ret[i].Value = e.ValueWO.ValueStringPointer()
+		}
 	}
 
 	return

--- a/internal/service/apprun_dedicated/resource_version.go
+++ b/internal/service/apprun_dedicated/resource_version.go
@@ -34,6 +34,7 @@ import (
 	ver "github.com/sacloud/sacloud-sdk-go/api/apprun-dedicated/apis/version"
 	"github.com/sacloud/sacloud-sdk-go/common/saclient"
 	"github.com/sacloud/terraform-provider-sakura/internal/common"
+	"github.com/sacloud/terraform-provider-sakura/internal/common/utils"
 	"github.com/sacloud/terraform-provider-sakura/internal/desc"
 	sacloudvalidator "github.com/sacloud/terraform-provider-sakura/internal/validator"
 )
@@ -42,16 +43,17 @@ type verResource struct{ resourceClient }
 
 type verResourceModel struct {
 	verModel
-	EnvVars                []envVarResourceModel `tfsdk:"env_vars"`
-	RegistryPassword       types.String          `tfsdk:"registry_password"`
-	RegistryPasswordAction types.String          `tfsdk:"registry_password_action"`
-	Timeouts               timeouts.Value        `tfsdk:"timeouts"`
+	SecretVars             []secretVarModel `tfsdk:"secret_vars"`
+	RegistryPassword       types.String     `tfsdk:"registry_password"`
+	RegistryPasswordAction types.String     `tfsdk:"registry_password_action"`
+	Timeouts               timeouts.Value   `tfsdk:"timeouts"`
 }
 
 var (
-	_ resource.Resource                = &verResource{}
-	_ resource.ResourceWithConfigure   = &verResource{}
-	_ resource.ResourceWithImportState = &verResource{}
+	_ resource.Resource                   = &verResource{}
+	_ resource.ResourceWithConfigure      = &verResource{}
+	_ resource.ResourceWithImportState    = &verResource{}
+	_ resource.ResourceWithValidateConfig = &verResource{}
 )
 
 func NewVersionResource() resource.Resource { return &verResource{resourceNamed("version")} }
@@ -236,7 +238,7 @@ func (r *verResource) Schema(ctx context.Context, _ resource.SchemaRequest, res 
 			},
 			"env_vars": schema.ListNestedAttribute{
 				Optional:      true,
-				Description:   "Environment variables",
+				Description:   "Environment variables.  Use `secret_vars` for secrets",
 				Validators:    []validator.List{listvalidator.SizeAtMost(50)},
 				PlanModifiers: []planmodifier.List{listplanmodifier.RequiresReplace()},
 				NestedObject: schema.NestedAttributeObject{
@@ -249,41 +251,106 @@ func (r *verResource) Schema(ctx context.Context, _ resource.SchemaRequest, res 
 						},
 						"value": schema.StringAttribute{
 							Optional:      true,
-							Description:   "The value.  Consider `value_wo` for secrets to keep them out of the state.  Omitting both this field and `value_wo` while `secret` is true retains old secret value",
+							Description:   "The value.  Use `secret_vars` for secrets.  Omitting this field with the deprecated `secret = true` retains the previous version's secret value",
 							Validators:    []validator.String{stringvalidator.LengthAtMost(4096)},
+							PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+						},
+						"secret": schema.BoolAttribute{
+							Optional:           true,
+							Computed:           true,
+							Default:            booldefault.StaticBool(false),
+							Description:        "Whether the value is sensitive",
+							DeprecationMessage: "The \"secret\" attribute is deprecated and will be removed in a future version. Omit it (it defaults to false) and put secrets in secret_vars instead.",
+							PlanModifiers:      []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
+						},
+					},
+				},
+			},
+			"secret_vars": schema.ListNestedAttribute{
+				Optional:      true,
+				Description:   "Secret environment variables.  Unlike `env_vars`, values are write-only and never land in the state.  `terraform import` puts every secret here; declare each as `{ key = \"...\" }` alone to adopt the imported version as is, and set `value_wo` only when a new version with a new value is wanted",
+				Validators:    []validator.List{listvalidator.SizeAtMost(50)},
+				PlanModifiers: []planmodifier.List{listplanmodifier.RequiresReplace()},
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"key": schema.StringAttribute{
+							Required:      true,
+							Description:   "Environment variable name",
+							Validators:    []validator.String{stringvalidator.LengthBetween(1, 255)},
 							PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 						},
 						"value_wo": schema.StringAttribute{
 							WriteOnly:   true,
 							Optional:    true,
-							Description: "The value, write-only.  Unlike `value` this never lands in the state, whatever `secret` is (`secret` only controls whether the API conceals the value).  Must be set together with `value_wo_version`",
+							Description: "The value, write-only.  Omitting this field retains the previous version's secret value.  Must be set together with `value_wo_version`",
 							Validators: []validator.String{
 								stringvalidator.LengthAtMost(4096),
-								stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("value")),
 								stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("value_wo_version")),
 							},
-							// No RequiresReplace here: a write-only value is null in both plan and state, so it could never fire.
-							// Replacement is driven by value_wo_version.
+							// no RequiresReplace: write-only values are always null in the plan
 						},
 						"value_wo_version": schema.Int32Attribute{
 							Optional:    true,
-							Description: "The version of the `value_wo` field.  This value must be greater than 0 when set.  Terraform cannot detect changes of write-only values, so increment this to create a new application version with the new `value_wo`.  Note that `terraform import` cannot restore this field; the first plan after importing replaces the version unless `value_wo` and `value_wo_version` are left out of the configuration",
+							Description: "The version of the `value_wo` field.  This value must be greater than 0 when set.  Terraform cannot detect changes of write-only values, so increment this to create a new application version with the new `value_wo`.  Note that `terraform import` cannot restore this field",
 							Validators: []validator.Int32{
 								int32validator.AtLeast(1),
 								int32validator.AlsoRequires(path.MatchRelative().AtParent().AtName("value_wo")),
 							},
 							PlanModifiers: []planmodifier.Int32{int32planmodifier.RequiresReplace()},
 						},
-						"secret": schema.BoolAttribute{
-							Required:      true,
-							Description:   "Whether the value is sensitive",
-							PlanModifiers: []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
-						},
 					},
 				},
 			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{Create: true, Delete: true}),
 		},
+	}
+}
+
+func (r *verResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, res *resource.ValidateConfigResponse) {
+	var envVars, secretVars types.List
+	res.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("env_vars"), &envVars)...)
+	res.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("secret_vars"), &secretVars)...)
+
+	if res.Diagnostics.HasError() || !utils.IsKnown(envVars) || !utils.IsKnown(secretVars) {
+		return
+	}
+
+	var envs []envVarModel
+	var secrets []secretVarModel
+	res.Diagnostics.Append(envVars.ElementsAs(ctx, &envs, true)...)
+	res.Diagnostics.Append(secretVars.ElementsAs(ctx, &secrets, true)...)
+
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	if n := len(envs) + len(secrets); n > 50 {
+		res.Diagnostics.AddAttributeError(
+			path.Root("secret_vars"),
+			"Too many environment variables",
+			fmt.Sprintf("env_vars and secret_vars together must have at most 50 elements, got %d.", n),
+		)
+	}
+
+	keys := make(map[string]struct{}, len(envs))
+	for _, e := range envs {
+		if utils.IsKnown(e.Key) {
+			keys[e.Key.ValueString()] = struct{}{}
+		}
+	}
+
+	for i, s := range secrets {
+		if !utils.IsKnown(s.Key) {
+			continue
+		}
+
+		if _, dup := keys[s.Key.ValueString()]; dup {
+			res.Diagnostics.AddAttributeError(
+				path.Root("secret_vars").AtListIndex(i).AtName("key"),
+				"Duplicate env_vars and secret_vars key",
+				fmt.Sprintf("The key %q is configured in both env_vars and secret_vars. The key must be unique across env_vars and secret_vars.", s.Key.ValueString()),
+			)
+		}
 	}
 }
 
@@ -457,26 +524,24 @@ func (v *verResourceModel) intoCreate(transitional *verResourceModel) (ret ver.C
 	return
 }
 
-// Write-only values never appear in the plan.  Take them from the config.
-// env_vars has no computed child attribute, so the plan is a copy of the config and the two lists are index-aligned.
-// Should that ever not hold, fail loudly rather than silently dropping a secret.
-func (v *verResourceModel) envVarsIntoCreate(config *verResourceModel) (ret []ver.EnvironmentVariable, diag diag.Diagnostics) {
-	if len(config.EnvVars) != len(v.EnvVars) {
-		diag.AddError("Create: Inconsistent Configuration", fmt.Sprintf("env_vars has %d elements in the plan but %d in the config", len(v.EnvVars), len(config.EnvVars)))
+// write-only values are not in the plan; take them from the config, which is index-aligned
+func (v *verResourceModel) envVarsIntoCreate(transitional *verResourceModel) (ret []ver.EnvironmentVariable, diag diag.Diagnostics) {
+	ret = common.MapTo(v.EnvVars, envVarModel.intoCreate)
+
+	if len(transitional.SecretVars) != len(v.SecretVars) {
+		diag.AddError("Create: Inconsistent Configuration", fmt.Sprintf("secret_vars has %d elements in the plan but %d in the config", len(v.SecretVars), len(transitional.SecretVars)))
 		return
 	}
 
-	ret = common.MapTo(v.EnvVars, envVarResourceModel.intoCreate)
+	for i, s := range v.SecretVars {
+		c := transitional.SecretVars[i]
 
-	for i, e := range config.EnvVars {
-		if key := e.Key.ValueString(); key != ret[i].Key {
-			diag.AddError("Create: Inconsistent Configuration", fmt.Sprintf("env_vars[%d] is %q in the plan but %q in the config", i, ret[i].Key, key))
+		if c.Key.ValueString() != s.Key.ValueString() {
+			diag.AddError("Create: Inconsistent Configuration", fmt.Sprintf("secret_vars[%d] is %q in the plan but %q in the config", i, s.Key.ValueString(), c.Key.ValueString()))
 			return
 		}
 
-		if !e.ValueWO.IsNull() {
-			ret[i].Value = e.ValueWO.ValueStringPointer()
-		}
+		ret = append(ret, s.intoCreate(c.ValueWO.ValueStringPointer())) // nil retains old secret value
 	}
 
 	return

--- a/internal/service/apprun_dedicated/resource_version_test.go
+++ b/internal/service/apprun_dedicated/resource_version_test.go
@@ -58,18 +58,14 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 						})),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("env_vars"), knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"key":              knownvalue.StringExact("ENV_VAR2"),
-								"value":            knownvalue.StringExact("value2"),
-								"value_wo":         knownvalue.Null(),
-								"value_wo_version": knownvalue.Null(),
-								"secret":           knownvalue.Bool(true),
+								"key":    knownvalue.StringExact("ENV_VAR2"),
+								"value":  knownvalue.StringExact("value2"),
+								"secret": knownvalue.Bool(true),
 							}),
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"key":              knownvalue.StringExact("ENV_VAR1"),
-								"value":            knownvalue.StringExact("value1"),
-								"value_wo":         knownvalue.Null(),
-								"value_wo_version": knownvalue.Null(),
-								"secret":           knownvalue.Bool(false),
+								"key":    knownvalue.StringExact("ENV_VAR1"),
+								"value":  knownvalue.StringExact("value1"),
+								"secret": knownvalue.Bool(false),
 							}),
 						})),
 					},
@@ -80,7 +76,8 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 					ImportStateVerify: true,
 
 					// env_vars is randomized.  Not equal to the config order by nature.
-					ImportStateVerifyIgnore: []string{"timeouts", "registry_password", "env_vars"},
+					// import puts secrets in secret_vars
+					ImportStateVerifyIgnore: []string{"timeouts", "registry_password", "env_vars", "secret_vars"},
 					ImportStateIdFunc: func(s *terraform.State) (string, error) {
 						rs, ok := s.RootModule().Resources[resourceName]
 						if !ok {
@@ -95,7 +92,7 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 		})
 	})
 
-	t.Run("write_only_env_var", func(t *testing.T) {
+	t.Run("secret_vars", func(t *testing.T) {
 		resourceName := "sakura_apprun_dedicated_version.main"
 		name := acctest.RandStringFromCharSet(14, acctest.CharSetAlphaNum)
 
@@ -105,46 +102,37 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 			CheckDestroy:             testCheckSakuraApprunDedicatedVersionDestroy,
 			Steps: []resource.TestStep{
 				{
-					Config: test.BuildConfigWithArgs(testAccSakuraResourceApprunDedicatedVersion_writeOnlyEnvVar, name, globalClusterID, "1", "s3cr3t"),
+					Config: test.BuildConfigWithArgs(testAccSakuraResourceApprunDedicatedVersion_secretVars, name, globalClusterID, "1", "s3cr3t"),
+					Check:  testCheckSakuraApprunDedicatedVersionEnvVars(resourceName, map[string]bool{"SECRET_VAR": true, "PLAIN_VAR": false}),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("version"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("env_vars"), knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"key":    knownvalue.StringExact("PLAIN_VAR"),
+								"value":  knownvalue.StringExact("plain"),
+								"secret": knownvalue.Bool(false),
+							}),
+						})),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("secret_vars"), knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
 								"key":              knownvalue.StringExact("SECRET_VAR"),
-								"value":            knownvalue.Null(),
 								"value_wo":         knownvalue.Null(),
 								"value_wo_version": knownvalue.Int32Exact(1),
-								"secret":           knownvalue.Bool(true),
-							}),
-							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"key":              knownvalue.StringExact("PLAIN_VAR"),
-								"value":            knownvalue.StringExact("plain"),
-								"value_wo":         knownvalue.Null(),
-								"value_wo_version": knownvalue.Null(),
-								"secret":           knownvalue.Bool(false),
 							}),
 						})),
 					},
 				},
 				{
 					// bump value_wo_version to roll out a new value_wo
-					Config: test.BuildConfigWithArgs(testAccSakuraResourceApprunDedicatedVersion_writeOnlyEnvVar, name, globalClusterID, "2", "r0tated"),
+					Config: test.BuildConfigWithArgs(testAccSakuraResourceApprunDedicatedVersion_secretVars, name, globalClusterID, "2", "r0tated"),
+					Check:  testCheckSakuraApprunDedicatedVersionEnvVars(resourceName, map[string]bool{"SECRET_VAR": true, "PLAIN_VAR": false}),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("version"), knownvalue.NotNull()),
-						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("env_vars"), knownvalue.ListExact([]knownvalue.Check{
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("secret_vars"), knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
 								"key":              knownvalue.StringExact("SECRET_VAR"),
-								"value":            knownvalue.Null(),
 								"value_wo":         knownvalue.Null(),
 								"value_wo_version": knownvalue.Int32Exact(2),
-								"secret":           knownvalue.Bool(true),
-							}),
-							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"key":              knownvalue.StringExact("PLAIN_VAR"),
-								"value":            knownvalue.StringExact("plain"),
-								"value_wo":         knownvalue.Null(),
-								"value_wo_version": knownvalue.Null(),
-								"secret":           knownvalue.Bool(false),
 							}),
 						})),
 					},
@@ -154,8 +142,8 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 					ImportState:       true,
 					ImportStateVerify: true,
 
-					// env_vars is randomized.  Not equal to the config order by nature.
-					ImportStateVerifyIgnore: []string{"timeouts", "registry_password", "env_vars"},
+					// env_vars and secret_vars are randomized, and import cannot restore value_wo_version
+					ImportStateVerifyIgnore: []string{"timeouts", "registry_password", "env_vars", "secret_vars"},
 					ImportStateIdFunc: func(s *terraform.State) (string, error) {
 						rs, ok := s.RootModule().Resources[resourceName]
 						if !ok {
@@ -250,6 +238,49 @@ func testCheckSakuraApprunDedicatedVersionDestroy(s *terraform.State) error {
 	return nil
 }
 
+// write-only values cannot be checked via the state; ask the API
+func testCheckSakuraApprunDedicatedVersionEnvVars(n string, expects map[string]bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		appID, err := uuid.Parse(rs.Primary.Attributes["application_id"])
+		if err != nil {
+			return fmt.Errorf("invalid application ID: %s", rs.Primary.Attributes["application_id"])
+		}
+
+		versionNum := int32(0)
+		_, err = fmt.Sscanf(rs.Primary.Attributes["version"], "%d", &versionNum)
+		if err != nil {
+			return fmt.Errorf("invalid version number: %s", rs.Primary.Attributes["version"])
+		}
+
+		api := ver.NewVersionOp(test.AccClientGetter().AppRunDedicatedClient, v1.ApplicationID(appID))
+		detail, err := api.Read(context.Background(), v1.ApplicationVersionNumber(versionNum))
+		if err != nil {
+			return err
+		}
+
+		got := make(map[string]bool, len(detail.EnvVars))
+		for _, e := range detail.EnvVars {
+			got[e.Key] = e.Secret
+		}
+
+		for key, secret := range expects {
+			actual, ok := got[key]
+			if !ok {
+				return fmt.Errorf("env var %q is missing on the API side", key)
+			}
+			if actual != secret {
+				return fmt.Errorf("env var %q: secret = %t on the API side, want %t", key, actual, secret)
+			}
+		}
+		return nil
+	}
+}
+
 var testAccSakuraResourceApprunDedicatedVersion_basic = `
 resource "sakura_apprun_dedicated_application" "main" {
   cluster_id     = "{{ .arg1 }}"
@@ -292,7 +323,8 @@ resource "sakura_apprun_dedicated_version" "main" {
 }
 `
 
-var testAccSakuraResourceApprunDedicatedVersion_writeOnlyEnvVar = `
+//nolint:gosec
+var testAccSakuraResourceApprunDedicatedVersion_secretVars = `
 resource "sakura_apprun_dedicated_application" "main" {
   cluster_id     = "{{ .arg1 }}"
   name           = "tfacc-{{ .arg0 }}"
@@ -316,15 +348,16 @@ resource "sakura_apprun_dedicated_version" "main" {
 
   env_vars = [
     {
+      key   = "PLAIN_VAR"
+      value = "plain"
+    }
+  ]
+
+  secret_vars = [
+    {
       key              = "SECRET_VAR"
       value_wo         = "{{ .arg3 }}"
       value_wo_version = {{ .arg2 }}
-      secret           = true
-    },
-    {
-      key    = "PLAIN_VAR"
-      value  = "plain"
-      secret = false
     }
   ]
 }

--- a/internal/service/apprun_dedicated/resource_version_test.go
+++ b/internal/service/apprun_dedicated/resource_version_test.go
@@ -58,14 +58,93 @@ func TestAccSakuraResourceApprunDedicatedVersion(t *testing.T) {
 						})),
 						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("env_vars"), knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"key":    knownvalue.StringExact("ENV_VAR2"),
-								"value":  knownvalue.StringExact("value2"),
-								"secret": knownvalue.Bool(true),
+								"key":              knownvalue.StringExact("ENV_VAR2"),
+								"value":            knownvalue.StringExact("value2"),
+								"value_wo":         knownvalue.Null(),
+								"value_wo_version": knownvalue.Null(),
+								"secret":           knownvalue.Bool(true),
 							}),
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"key":    knownvalue.StringExact("ENV_VAR1"),
-								"value":  knownvalue.StringExact("value1"),
-								"secret": knownvalue.Bool(false),
+								"key":              knownvalue.StringExact("ENV_VAR1"),
+								"value":            knownvalue.StringExact("value1"),
+								"value_wo":         knownvalue.Null(),
+								"value_wo_version": knownvalue.Null(),
+								"secret":           knownvalue.Bool(false),
+							}),
+						})),
+					},
+				},
+				{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+
+					// env_vars is randomized.  Not equal to the config order by nature.
+					ImportStateVerifyIgnore: []string{"timeouts", "registry_password", "env_vars"},
+					ImportStateIdFunc: func(s *terraform.State) (string, error) {
+						rs, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return "", fmt.Errorf("not found: %s", resourceName)
+						}
+						appID := rs.Primary.Attributes["application_id"]
+						version := rs.Primary.Attributes["version"]
+						return fmt.Sprintf("%s/%s", appID, version), nil
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("write_only_env_var", func(t *testing.T) {
+		resourceName := "sakura_apprun_dedicated_version.main"
+		name := acctest.RandStringFromCharSet(14, acctest.CharSetAlphaNum)
+
+		resource.ParallelTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: test.AccProtoV6ProviderFactories,
+			PreCheck:                 AccPreCheck(t),
+			CheckDestroy:             testCheckSakuraApprunDedicatedVersionDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: test.BuildConfigWithArgs(testAccSakuraResourceApprunDedicatedVersion_writeOnlyEnvVar, name, globalClusterID, "1", "s3cr3t"),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("version"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("env_vars"), knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"key":              knownvalue.StringExact("SECRET_VAR"),
+								"value":            knownvalue.Null(),
+								"value_wo":         knownvalue.Null(),
+								"value_wo_version": knownvalue.Int32Exact(1),
+								"secret":           knownvalue.Bool(true),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"key":              knownvalue.StringExact("PLAIN_VAR"),
+								"value":            knownvalue.StringExact("plain"),
+								"value_wo":         knownvalue.Null(),
+								"value_wo_version": knownvalue.Null(),
+								"secret":           knownvalue.Bool(false),
+							}),
+						})),
+					},
+				},
+				{
+					// bump value_wo_version to roll out a new value_wo
+					Config: test.BuildConfigWithArgs(testAccSakuraResourceApprunDedicatedVersion_writeOnlyEnvVar, name, globalClusterID, "2", "r0tated"),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("version"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("env_vars"), knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"key":              knownvalue.StringExact("SECRET_VAR"),
+								"value":            knownvalue.Null(),
+								"value_wo":         knownvalue.Null(),
+								"value_wo_version": knownvalue.Int32Exact(2),
+								"secret":           knownvalue.Bool(true),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"key":              knownvalue.StringExact("PLAIN_VAR"),
+								"value":            knownvalue.StringExact("plain"),
+								"value_wo":         knownvalue.Null(),
+								"value_wo_version": knownvalue.Null(),
+								"secret":           knownvalue.Bool(false),
 							}),
 						})),
 					},
@@ -207,6 +286,44 @@ resource "sakura_apprun_dedicated_version" "main" {
     {
       key    = "ENV_VAR1"
       value  = "value1"
+      secret = false
+    }
+  ]
+}
+`
+
+var testAccSakuraResourceApprunDedicatedVersion_writeOnlyEnvVar = `
+resource "sakura_apprun_dedicated_application" "main" {
+  cluster_id     = "{{ .arg1 }}"
+  name           = "tfacc-{{ .arg0 }}"
+  active_version = null
+}
+
+resource "sakura_apprun_dedicated_version" "main" {
+  application_id = sakura_apprun_dedicated_application.main.id
+  cpu            = 100
+  memory         = 256
+  scaling_mode   = "manual"
+  fixed_scale    = 1
+  image          = "nginx:latest"
+
+  exposed_ports = [
+    {
+      target_port = 80
+      lb_port     = null
+    }
+  ]
+
+  env_vars = [
+    {
+      key              = "SECRET_VAR"
+      value_wo         = "{{ .arg3 }}"
+      value_wo_version = {{ .arg2 }}
+      secret           = true
+    },
+    {
+      key    = "PLAIN_VAR"
+      value  = "plain"
       secret = false
     }
   ]


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #338 

### このPRはどういう変更を行いますか？  
sakura_apprun_dedicated_version の env_vars[].value は secret = true でも平文が tfstate に残ります。
プロバイダーの既存規約(*_wo / *_wo_version、同リソースの registry_password)に合わせて write-only 版を追加します。

- env_vars[].value_wo (WriteOnly): value と排他とし、value_wo_version と同時指定必須
- env_vars[].value_wo_version: これを上げると新しいバージョンを作成
- Create は registry_password と同様に req.Config から値を取得(リスト要素のため plan とインデックス・キーで突き合わせ、不一致時はエラー)
- Read は value_wo で設定した env var の value を state に書かない(API が値を返す場合も同様)
- 既存の value は互換性のため維持
- データソースは write-only 属性を持てないため、EnvVars を verModel からリソース用/データソース用の各モデルに分離(データソースの挙動は不変)
- ユニットテストを追加、受け入れテストに write_only_env_var(作成 → value_wo_version を上げて更新 → import)を追加。  
  
ご判断いただきたい点:
- terraform import は value_wo_version を復元できないため、それを書いた設定で import 直後に plan すると置換になりますので、
description に明記しました(import 時は value_wo を書かず secret = true で既存値を維持する運用)。

### ドキュメントの変更は必要ですか？
再生成済みです。  